### PR TITLE
Log instead of printing

### DIFF
--- a/base/relengapi/app.py
+++ b/base/relengapi/app.py
@@ -15,6 +15,7 @@ from relengapi.lib import monkeypatches
 from relengapi.lib.actions import Actions
 import pkg_resources
 import relengapi
+import logging
 
 # set up the 'relengapi' namespace; it's a namespaced module, so no code
 # is allowed in __init__.py
@@ -25,6 +26,8 @@ relengapi.apimethod = api.apimethod
 
 # apply monkey patches
 monkeypatches.monkeypatch()
+
+logger = logging.getLogger(__name__)
 
 def create_app(cmdline=False, test_config=None):
     app = Flask(__name__)
@@ -43,12 +46,12 @@ def create_app(cmdline=False, test_config=None):
     # get blueprints from pkg_resources
     for ep in pkg_resources.iter_entry_points('relengapi_blueprints'):
         if cmdline:
-            print " * registering blueprint", ep.name
+            logger.info(" * registering blueprint %s", ep.name)
         app.register_blueprint(ep.load(), url_prefix='/%s' % ep.name)
 
     # set up a random session key if none is specified
     if not app.config.get('SECRET_KEY'):
-        print " * WARNING: setting per-process session key"
+        logger.warning(" * setting per-process session key - sessions will be reset on process restart")
         app.secret_key = os.urandom(24)
 
     @app.before_request

--- a/base/relengapi/blueprints/base/__init__.py
+++ b/base/relengapi/blueprints/base/__init__.py
@@ -5,10 +5,11 @@
 from relengapi import subcommands
 from flask import Blueprint
 from flask import current_app
+import logging
 
 
 bp = Blueprint('base', __name__)
-
+logger = logging.getLogger(__name__)
 
 class ServeSubcommand(subcommands.Subcommand):
 
@@ -40,7 +41,7 @@ class CreateDBSubcommand(subcommands.Subcommand):
 
     def run(self, parser, args):
         for dbname in current_app.db.database_names:
-            print " * creating tables for database %s" % (dbname,)
+            logger.info(" * creating tables for database %s", dbname)
             meta = current_app.db.metadata[dbname]
             engine = current_app.db.engine(dbname)
             meta.create_all(bind=engine)

--- a/base/relengapi/subcommands.py
+++ b/base/relengapi/subcommands.py
@@ -5,6 +5,19 @@
 import relengapi.app
 import pkg_resources
 import argparse
+import sys
+import logging.handlers
+
+
+def setupConsoleLogging():
+    root = logging.getLogger('')
+    root.setLevel(logging.NOTSET)
+    formatter = logging.Formatter('%(asctime)s %(message)s')
+
+    stdout_log = logging.StreamHandler(sys.stdout)
+    stdout_log.setLevel(logging.DEBUG)
+    stdout_log.setFormatter(formatter)
+    root.addHandler(stdout_log)
 
 
 class Subcommand(object):
@@ -32,6 +45,8 @@ def main():
         subparser.set_defaults(_run=subcommand.run)
 
     args = parser.parse_args()
+
+    setupConsoleLogging()
 
     app = relengapi.app.create_app(cmdline=True)
     with app.app_context():


### PR DESCRIPTION
Set up Python logging early in the startup sequence (before the app is
created), and log instead of printing.  Fixes #19.
