### PR TITLE
Use a static secret key for tokens, when none is given

### DIFF
--- a/base/relengapi/blueprints/tokenauth/__init__.py
+++ b/base/relengapi/blueprints/tokenauth/__init__.py
@@ -168,4 +168,7 @@ def token_loader():
 @bp.record
 def init_blueprint(state):
     app = state.app
-    app.tokenauth_serializer = JSONWebSignatureSerializer(app.secret_key)
+    if not app.secret_key:
+        logger.warning("The `SECRET_KEY` setting is not set; tokens will be signed with an insecure, static key")
+    secret_key = app.secret_key or 'NOT THAT SECRET'
+    app.tokenauth_serializer = JSONWebSignatureSerializer(secret_key)


### PR DESCRIPTION
When the user doesn't specify SECRET_KEY, `app.secret_key` is None, not
a per-session value as one might hope.  In this case, tokens are
generated using a non-secret secret.  This is good for development, but
not for production, so the code issues a warning, too.

@petemoore, what do you think?
