### PR TITLE
Don't always 403 on permission fail if logged out.

### DIFF
--- a/base/relengapi/lib/permissions.py
+++ b/base/relengapi/lib/permissions.py
@@ -4,7 +4,7 @@
 
 import wrapt
 from flask import abort
-from flask.ext.login import current_user
+from flask.ext.login import current_user, login_required
 
 
 class Permission(tuple):
@@ -70,6 +70,7 @@ class Permissions(Permission):
                     "Cannot require undocumented permission %s" % perm)
 
         @wrapt.decorator
+        @login_required
         def req(wrapped, instance, args, kwargs):
             if not can(*permissions):
                 abort(403)


### PR DESCRIPTION
Right now we're just doing an `abort(403)` on a permission check fail, even if the user is logged out. We should really prompt the user to log in before deciding they don't have permission. 
