### PR TITLE
Docs on documenting non-REST API endpoints

### DIFF
--- a/base/docs/development/@relengapi/api_methods.rst
+++ b/base/docs/development/@relengapi/api_methods.rst
@@ -69,6 +69,17 @@ To return a success code other than 200 or include headers, simply return a tupl
     Returns a decorator for API methods as described above.
     The arguments are those for WSME's @\ signature_ decorator.
 
+
+Non-REST Endpoints
+..................
+
+Sometimes endpoints don't take or return JSON documents.
+For user convenience, this should be minimized.
+
+In cases where this is necessary, the ``apimethod`` decorator can't be used.
+Instead, your view function must do any encoding, decoding, and error handling itself.
+See below for help documenting such endpoints.
+
 Exceptions
 ----------
 
@@ -80,6 +91,8 @@ However, when the request does not specify ``text/html``, the exception is encod
 HTTP Errors again have the appropriate status code, while other exceptions are treated as 500 ISE's.
 The ``error`` key of the returned JSON contains keys ``code``, ``name``, and ``description``.
 When debugging is enabled, the exception information also contains a ``traceback`` key.
+
+.. _api-documentation:
 
 Documentation
 -------------
@@ -145,6 +158,29 @@ Similarly, endpoints are referenced using their Flask endpoint name, e.g.,
 .. code-block:: none
 
     Use :api:endpoint:`tokenauth.issue_token` to issue tokens.
+
+Non-REST Endpoints
+..................
+
+Endpoints which aren't sufficiently RESTful to be automatically documented can be described with the ``endpoint`` directive:
+
+.. code-block:: none
+
+    .. endpoint:: endpoint.name
+        POST /foo/<name>
+        PATCH /foo/<name>
+
+        :param name: name of the foo
+        :body: foo document
+        :response: updated foo document
+
+        Update or set the contents of a Foo.
+        With PATCH, the new and existing foo documents will be merged.
+
+The first argument is the name of the endpoint (usually the dotted combination of the blueprint and function name).
+The remaining arguments alternate between method names and paths.
+
+The docfields are ``param`` for request parameters, ``body`` for the request body, and ``response`` for the response body.
 
 .. _WSME: http://wsme.readthedocs.org/
 .. _signature: http://wsme.readthedocs.org/en/latest/api.html#wsme.signature

--- a/base/docs/development/@relengapi/docs.rst
+++ b/base/docs/development/@relengapi/docs.rst
@@ -26,6 +26,8 @@ The ``index.rst`` file can contain a ``toctree`` pointing to other files, or jus
 
 For example, usage documentation for a "bumper" project would be in ``docs/usage/relengapi-bumper/index.rst``.
 
+See :ref:`api-documentation` for information on documenting REST API endpoints and types.
+
 Building Documentation
 ----------------------
 


### PR DESCRIPTION
@petemoore it looks like this would apply to mapper, specifically.  What do you think?
