### PR TITLE
Introduce `relengapi.time` module with a `now` method

### DIFF
--- a/base/relengapi/lib/time.py
+++ b/base/relengapi/lib/time.py
@@ -1,0 +1,10 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import datetime
+import pytz
+
+
+def now():
+    return datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)

--- a/base/relengapi/tests/test_time.py
+++ b/base/relengapi/tests/test_time.py
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from relengapi.lib import time
+from nose.tools import eq_
+import pytz
+
+
+def test_now():
+    n = time.now()
+    eq_(n.tzinfo, pytz.UTC)


### PR DESCRIPTION
I suspect at some point I'll also want a "format time interval" method, for example for pretty-printing badpenny task times.
