### PR TITLE
Don't use the runtime app context for tests

### DIFF
--- a/base/relengapi/blueprints/base/__init__.py
+++ b/base/relengapi/blueprints/base/__init__.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from relengapi import subcommands
+from flask import Flask
 from flask import Blueprint
 from flask import current_app
 import logging
@@ -62,4 +63,7 @@ class RunTestsSubcommand(subcommands.Subcommand):
     def run(self, parser, args):
         import nose
         sys.argv = [sys.argv[0]] + args.nose_args
-        nose.main()
+        # push a fake app context to avoid tests accidentally using the
+        # runtime app context (for example, the development DB)
+        with Flask(__name__).app_context():
+            nose.main()


### PR DESCRIPTION
I noticed test data was leaking into my dev DB because I'd forgotten `@test_context`.  This makes tests fail under that condition, instead.
