### PR TITLE
Use better defaults for DB URIs when no config is present

### DIFF
--- a/docs/deployment/@relengapi/config.rst
+++ b/docs/deployment/@relengapi/config.rst
@@ -21,15 +21,12 @@ Databases
 Releng API, as a kind of glue, generally connects to a numnber of databases.
 Each database has a short name, and requires that a longer SQLAlchemy URL be configured for it.
 
-This is done in the ``SQLALCHEMY_DATABASE_URIS`` configuration, which is a dictionary mapping names to URLs.
+This is done in the ``SQLALCHEMY_DATABASE_URIS`` configuration, which is a dictionary mapping names to URIs.
+If this configuration key is not present, then RelengAPI will create SQLite databases in the root of the source directory.
+This is effective for development, but certainly not for production.
 
-The databases for the base blueprint are
-
-  * ``relengapi`` - the Releng API's own DB
-  * ``scheduler`` - the Buildbot scheduler DB
-  * ``status`` - the Buildbot status DB
-
-Other blueprints may require additional bind URIs.
+The database for the relengapi core is named ``relengapi``.
+Other blueprints may require additional URIs.
 
 .. _Deployment-Authentication:
 

--- a/relengapi/app.py
+++ b/relengapi/app.py
@@ -83,14 +83,6 @@ class VersionInfo(wsme.types.Base):
     blueprints = {unicode: BlueprintInfo}
 
 
-def apply_default_config(app):
-    db_file = 'sqlite:///{}'.format(
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), '../relengapi.db')
-    )
-    logger.warning("Creating a sqlite database: {}".format(db_file))
-    app.config['SQLALCHEMY_DATABASE_URIS'] = dict(relengapi=db_file)
-
-
 def create_app(cmdline=False, test_config=None):
     blueprints = get_blueprints()
 
@@ -102,9 +94,8 @@ def create_app(cmdline=False, test_config=None):
         if env_var in os.environ and os.environ[env_var]:
             app.config.from_envvar(env_var)
         else:
-            logger.warning("using default settings; to configure relengapi, set "
+            logger.warning("Using default settings; to configure relengapi, set "
                            "%s to point to your settings file" % env_var)
-            apply_default_config(app)
 
     # add the necessary components to the app
     app.db = db.make_db(app)

--- a/relengapi/tests/test_db.py
+++ b/relengapi/tests/test_db.py
@@ -40,6 +40,29 @@ class DevTable(db.declarative_base('test_db')):
     date = sa.Column(db.UTCDateTime(timezone=True))
 
 
+@TestContext()
+def test_get_db_config_default(app):
+    app.config.pop('SQLALCHEMY_DATABASE_URIS')
+    dir = os.path.join(os.path.dirname(db.__file__), '../..')
+    dir = os.path.abspath(dir)
+    abc_uri = app.db._get_db_config('abc')
+    eq_(abc_uri, 'sqlite:///' + os.path.join(dir, 'abc.db'))
+
+
+@TestContext()
+def test_get_db_config_configured(app):
+    app.config['SQLALCHEMY_DATABASE_URIS'] = {'abc': 'foo:///bar'}
+    abc_uri = app.db._get_db_config('abc')
+    eq_(abc_uri, 'foo:///bar')
+
+
+@TestContext()
+def test_get_db_config_configured_not_this_db(app):
+    app.config['SQLALCHEMY_DATABASE_URIS'] = {'abc': 'foo:///bar'}
+    assert_raises(KeyError, lambda:
+                  app.db._get_db_config('xyz'))
+
+
 @TestContext(databases=['test_db'])
 def test_ensure_empty(app):
     session = app.db.session('test_db')

--- a/settings_example.py
+++ b/settings_example.py
@@ -2,15 +2,18 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import os
-
-SQLALCHEMY_DATABASE_URIS = {
-    # Edit the next line to specify a proper path/db name
-    'relengapi': 'sqlite:///{}'.format(
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), 'relengapi.db')
-    ),
-    # .. add other database URIs here, as appropriate for the blueprints
-}
+# RelengAPI can use multiple databases when several blueprints are installed.  Each is
+# configured with a key in this dictionary.  For example:
+#
+# SQLALCHEMY_DATABASE_URIS = {
+#    'relengapi': 'sqlite:////tmp/relengapi.db',
+#    'clobberer': 'sqlite:////tmp/clobberer.db',
+#    # .. add other database URIs here, as appropriate for the blueprints
+# }
+#
+# You can use any SQLAlchemy-style database URI.  The default, if no URI
+# configuration is present, is to use '*.db' files in the directory containing
+# the RelengAPI source code.
 
 # ===== Authentication and Authorization =====
 


### PR DESCRIPTION
This puts each relengapi database in its own sqlite database, but _only_
if `SQLALCHEMY_DATABASE_URIS` is not present at all.  Otherwise, an
unknown database is considered an error.

This is one way to address #138
