### PR TITLE
`raise self.error(..)` is not how to handle errors in a Docutils Domain

### DIFF
--- a/relengapi/lib/apidoc.py
+++ b/relengapi/lib/apidoc.py
@@ -132,8 +132,8 @@ class EndpointDirective(ObjectDescription):
     def get_signatures(self):
         self.endpoint_name = self.arguments.pop(0)
         if len(self.arguments) % 2 != 0:
-            raise self.error("api:endpoint expects an odd number of arguments "
-                             "(endpoint method path method path ..)")
+            raise RuntimeError("api:endpoint expects an odd number of arguments "
+                               "(endpoint method path method path ..)")
         rv = []
         while self.arguments:
             methods, path = self.arguments[:2]
@@ -202,7 +202,7 @@ class AutoEndpointDirective(Directive):
                 to_document.add((endpoint, func, tuple(rules)))
                 found = True
             if not found:
-                raise self.error('no endpoints found matching %s' % (arg,))
+                raise RuntimeError('no endpoints found matching %s' % (arg,))
 
         # sort by the first rule of each endpoint
         to_document = sorted(
@@ -254,7 +254,7 @@ class AutoTypeDirective(Directive):
         for ct in wsme.types.registry.complex_types:
             if ct.__name__ == name or (hasattr(ct, '_name') and ct._name == name):
                 return ct
-        raise self.error("no type named %r" % (name,))
+        raise RuntimeError("no type named %r" % (name,))
 
     def get_attr_docs(self, ty):
         # this reaches into some undocumented stuff in sphinx to
@@ -328,7 +328,7 @@ class ApiDomain(Domain):
         try:
             todocname, targetname = targets[target]
         except KeyError:
-            raise self.error("MISSING REFERENCE: api:%s:%s" % (typ, target))
+            raise RuntimeError("MISSING REFERENCE: api:%s:%s" % (typ, target))
 
         return make_refnode(builder, fromdocname,
                             todocname, targetname,


### PR DESCRIPTION
```
Traceback (most recent call last):lengapi/badpenny                                                                                                                                                                                                                       
  File "/home/dustin/code/relengapi/t/relengapi/sandbox/bin/relengapi", line 9, in <module>
    load_entry_point('relengapi==0.3', 'console_scripts', 'relengapi')()
  File "/home/dustin/code/relengapi/t/relengapi/relengapi/lib/subcommands.py", line 62, in main
    args._subcommand.run(parser, args)
  File "/home/dustin/code/relengapi/t/relengapi/relengapi/blueprints/docs/__init__.py", line 134, in run
    support.build()
  File "/home/dustin/code/relengapi/t/relengapi/sandbox/lib/python2.7/site-packages/sphinx/websupport/__init__.py", line 127, in build
    app.build()
  File "/home/dustin/code/relengapi/t/relengapi/sandbox/lib/python2.7/site-packages/sphinx/application.py", line 220, in build
    self.builder.build_update()
  File "/home/dustin/code/relengapi/t/relengapi/sandbox/lib/python2.7/site-packages/sphinx/builders/__init__.py", line 214, in build_update
    'out of date' % len(to_build))
  File "/home/dustin/code/relengapi/t/relengapi/sandbox/lib/python2.7/site-packages/sphinx/builders/__init__.py", line 276, in build
    self.write(docnames, list(updated_docnames), method)
  File "/home/dustin/code/relengapi/t/relengapi/sandbox/lib/python2.7/site-packages/sphinx/builders/__init__.py", line 320, in write
    self._write_serial(sorted(docnames), warnings)
  File "/home/dustin/code/relengapi/t/relengapi/sandbox/lib/python2.7/site-packages/sphinx/builders/__init__.py", line 331, in _write_serial
    doctree = self.env.get_and_resolve_doctree(docname, self)
  File "/home/dustin/code/relengapi/t/relengapi/sandbox/lib/python2.7/site-packages/sphinx/environment.py", line 1117, in get_and_resolve_doctree
    self.resolve_references(doctree, docname, builder)
  File "/home/dustin/code/relengapi/t/relengapi/sandbox/lib/python2.7/site-packages/sphinx/environment.py", line 1348, in resolve_references
    typ, target, node, contnode)
  File "/home/dustin/code/relengapi/t/relengapi/relengapi/lib/apidoc.py", line 331, in resolve_xref
    raise self.error("MISSING REFERENCE: api:%s:%s" % (typ, target))
AttributeError: 'ApiDomain' object has no attribute 'error'
```

And no, I don't know what the right way is!
