### PR TITLE
Add simplejson to requirements to fix celery json encoder

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "wsme",
         "croniter",
         "python-dateutil",
+        "simplejson",
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
So in writing stuff for slaveloan I hit https://github.com/celery/celery/issues/2033, which indicates there is no workaround for the builtin json encoder at the moment. However it also indicates its fixable by adding in simplejson.

I chose to add additional tests at the same time as testing this, verifying various states of chain and group, and the same exact test with and without json this so that issues with the json encoder will be apparently an issue with json. (Also allows us to try and back this piece out later, with confidence, if we suspect its fixed)
