### PR TITLE
Permissions should support a way to say "all authorized humans"

### DIFF
--- a/docs/deployment/@relengapi/config.rst
+++ b/docs/deployment/@relengapi/config.rst
@@ -125,6 +125,7 @@ The configuration looks like this::
         'group-permissions': {
             'team_relops': ['tasks.create', 'base.tokens.view'],
             'team_releng': ['base.tokens.issue', 'base.tokens.view'],
+            '<everyone>': ['branches.view'],
         },
 
         # Base LDAP URI
@@ -144,6 +145,7 @@ The configuration looks like this::
  
 Permissions are cumulative: a person has a permission if they are a member of any group configured with that permission.
 In the example above, a user in both ``team_relops`` and ``team_releng`` would have permission to create tasks and to issue and view tokens.
+The group name ``<everyone>`` is treated specially: it grants permission to all authenticated users, regardless of authentication mechanism.
 
 Users must be under the subtree named by ``user_base``, and similarly groups must be under ``group_base``.
 Users must have object class ``inetOrgPerson``, and groups must have object class ``groupOfNames``.

--- a/relengapi/lib/auth/ldap_group_authz.py
+++ b/relengapi/lib/auth/ldap_group_authz.py
@@ -62,7 +62,7 @@ class LdapGroups(object):
         groups = self.get_user_groups(user.authenticated_email)
         if self.debug:
             self.logger.debug("Got groups %s for user %s", groups, user)
-        allowed_permissions = set()
+        allowed_permissions = set(self.group_permissions.get('<everyone>', []))
         for group in groups:
             for perm in self.group_permissions.get(group, []):
                 allowed_permissions.add(perm)

--- a/relengapi/tests/test_lib_auth_ldap_group_authz.py
+++ b/relengapi/tests/test_lib_auth_ldap_group_authz.py
@@ -153,3 +153,17 @@ def test_on_permissions_stale_groups_unknown_groups(app):
     lg.get_user_groups = lambda mail: ['group3', 'nosuch']
     lg.on_permissions_stale('sender', user, permissions)
     eq_(permissions, set([p.test_lga.bar]))
+
+EVERYONE_CONFIG = copy.deepcopy(CONFIG)
+EVERYONE_CONFIG['RELENGAPI_PERMISSIONS'][
+    'group-permissions']['<everyone>'] = ['test_lga.bar']
+
+
+@test_context.specialize(config=EVERYONE_CONFIG)
+def test_on_permissions_everyone(app):
+    user = auth.HumanUser('jimmy')
+    permissions = set()
+    lg = ldap_group_authz.LdapGroups(app)
+    lg.get_user_groups = lambda mail: []
+    lg.on_permissions_stale('sender', user, permissions)
+    eq_(permissions, set([p.test_lga.bar]))


### PR DESCRIPTION
This could be useful for Persona Auth and LDAP auth (token auth shouldn't use it)

Basically a way to say "somepermission" is good for any logged in people.

I'm thinking '`__all__`'

Part of the reasoning is so that we can give explicit perms for things to tokenauth users, rather than 'all'
