### PR TITLE
Display UI operations

### DIFF
--- a/relengapi/static/js/relengapi.js
+++ b/relengapi/static/js/relengapi.js
@@ -4,8 +4,37 @@
 angular.module('relengapi', []);
 
 angular.module('relengapi').config(function($httpProvider) {
+    var summarize_config = function(config) {
+        var meth = config.method;
+        var url = config.url;
+        return meth + " " + url;
+    };
     $httpProvider.interceptors.push(function($q) {
         return {
+            'request': function(config) {
+                if (config.is_restapi_request) {
+                    if (config.data) {
+                        // Firefox will helpfully produce a clickable rendition of the data
+                        console.log("RelengAPI request:", summarize_config(config),
+                                    'body', JSON.parse(config.data));
+                    } else {
+                        console.log("RelengAPI request:", summarize_config(config));
+                    }
+                }
+                return config;
+            },
+            'response': function(response) {
+                if (response.config.is_restapi_request) {
+                    if (response.data) {
+                        console.log("RelengAPI response:", summarize_config(response.config),
+                                    'HTTP', response.status, 'body', response.data);
+                    } else {
+                        console.log("RelengAPI response:", summarize_config(response.config),
+                                    'HTTP', response.status);
+                    }
+                }
+                return response;
+            },
             'responseError': function(response) {
                 if (response.config.is_restapi_request) {
                     var message;


### PR DESCRIPTION
Every UI operation should be calling documented API methods via HTTP.  Some $httpProvider interceptors should be able to log those calls and display them in the browser.  This makes it easy for a user to click around the UI until they figure out what they want to do, then quickly see how to automate it.
