### PR TITLE
relengapi_metadata is not installed

### DIFF
--- a/docs/development/@relengapi/blueprints.rst
+++ b/docs/development/@relengapi/blueprints.rst
@@ -80,16 +80,24 @@ Any conflicts may identify fixes required for continued compatibility with the c
 Project Metadata
 ----------------
 
-You can include metadata about your project in a file named ``setup.cfg`` in the same directory as ``setup.py``.
-Include them in a ``[relengapi]`` section.
-The currently supported keys are self explanatory, and shown below.
+You can include metadata about your project that will be displayed to the user.
+Create a dictionary with zero or more of:
 
-.. code-block:: none
+ * ``repository_of_record`` -- where contributors should look to see the source code
+ * ``bug_report_url`` -- where contributors should report bugs, in the unlikely event there are any
 
-    [relengapi]
-    repository_of_record = https://git.mozilla.org/?p=build/relengapi.git
-    bug_report_url = https://github.com/mozilla/build-relengapi/issues
+This dictionary can be at any Python path you would like.
+For simple, one-blueprint projects, this is often in the blueprint module itself, e.g., ``relengapi.blueprints.skeleton``.
+Wherever you choose, add a reference to it in your ``setup.py``::
 
+    setup(..,
+        entry_points={
+            "relengapi.metadata": [
+                'relengapi-bubbler = relengapi.blueprints.bubbler:metadata',
+            ],
+    )
+
+The "key" for the entry point must match the lower-cased name of your Python project (the distribution ``key``).
 
 Other Useful Stuff
 ------------------

--- a/relengapi/app.py
+++ b/relengapi/app.py
@@ -140,3 +140,8 @@ def create_app(cmdline=False, test_config=None):
         return VersionInfo(distributions=dists, blueprints=blueprints)
 
     return app
+
+metadata = {
+    'repository_of_record': 'https://git.mozilla.org/?p=build/relengapi.git',
+    'bug_report_url': 'https://github.com/mozilla/build-relengapi/issues',
+}

--- a/relengapi/tests/test_lib_introspection.py
+++ b/relengapi/tests/test_lib_introspection.py
@@ -17,13 +17,7 @@ def test_get_distributions():
     eq_(distributions['relengapi'].project_name, 'relengapi')
 
 
-def test_get_relengapi_metadata_this_dist():
+def test_metadata():
     distributions = introspection.get_distributions()
-    meta = introspection._get_relengapi_metadata(distributions['relengapi'])
+    meta = distributions['relengapi'].relengapi_metadata
     assert 'repository_of_record' in meta
-
-
-def test_get_relengapi_metadata_no_data():
-    distributions = introspection.get_distributions()
-    meta = introspection._get_relengapi_metadata(distributions['flask'])
-    eq_(meta, {})

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,3 @@
 traverse-namespace = 1
 
 where = .
-
-[relengapi]
-repository_of_record = https://git.mozilla.org/?p=build/relengapi.git
-bug_report_url = https://github.com/mozilla/build-relengapi/issues

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,9 @@ setup(
         ],
     },
     entry_points={
+        "relengapi.metadata": [
+            'relengapi = relengapi.app:metadata',
+        ],
         "relengapi.blueprints": [
             'base = relengapi.blueprints.base:bp',
             'auth = relengapi.blueprints.auth:bp',


### PR DESCRIPTION
When a dist is installed, its `setup.cfg` is no longer available.  So all of the handy `relengapi_metadata` in there is no longer available.  Apparently this is just hard!!