### PR TITLE
Add setting for celery logging

### DIFF
--- a/relengapi/lib/celery.py
+++ b/relengapi/lib/celery.py
@@ -7,17 +7,14 @@ from __future__ import absolute_import
 import logging
 
 from celery import Celery
-from celery.signals import after_setup_logger
+from celery.signals import celeryd_after_setup
 from flask import current_app
 from werkzeug.local import LocalProxy
 
 _defined_tasks = {}
-_relengapi_log_lvl = None  # Used for celery log level
 
 
 def make_celery(app):
-    global _relengapi_log_lvl
-    _relengapi_log_lvl = app.config.get("RELENGAPI_CELERY_LOG_LEVEL", None)
     broker = app.config.get('CELERY_BROKER_URL', 'memory://')
     celery = Celery(app.import_name, broker=broker)
     celery.conf.update(app.config)
@@ -56,12 +53,10 @@ def task(*args, **kwargs):
     return inner(**kwargs)
 
 
-def after_setup_logger_handler(sender=None, logger=None, loglevel=None,
-                               logfile=None, format=None,
-                               colorize=None, **kwds):
+@celeryd_after_setup.connect
+def setup_relengapi_logging(sender, instance, conf, **kwargs):
+    _relengapi_log_lvl = conf.get("RELENGAPI_CELERY_LOG_LEVEL", None)
     if _relengapi_log_lvl:
         n = logging.getLogger('relengapi')
         n.setLevel(_relengapi_log_lvl)
         n.debug("Setting relengapi logger to %s", _relengapi_log_lvl)
-
-after_setup_logger.connect(after_setup_logger_handler)

--- a/relengapi/lib/celery.py
+++ b/relengapi/lib/celery.py
@@ -4,14 +4,20 @@
 
 from __future__ import absolute_import
 
+import logging
+
 from celery import Celery
+from celery.signals import after_setup_logger
 from flask import current_app
 from werkzeug.local import LocalProxy
 
 _defined_tasks = {}
+_relengapi_log_lvl = None  # Used for celery log level
 
 
 def make_celery(app):
+    global _relengapi_log_lvl
+    _relengapi_log_lvl = app.config.get("RELENGAPI_CELERY_LOG_LEVEL", None)
     broker = app.config.get('CELERY_BROKER_URL', 'memory://')
     celery = Celery(app.import_name, broker=broker)
     celery.conf.update(app.config)
@@ -48,3 +54,14 @@ def task(*args, **kwargs):
             '@db.task() takes exactly 1 argument ({0} given)'.format(
                 sum([len(args), len(kwargs)])))
     return inner(**kwargs)
+
+
+def after_setup_logger_handler(sender=None, logger=None, loglevel=None,
+                               logfile=None, format=None,
+                               colorize=None, **kwds):
+    if _relengapi_log_lvl:
+        n = logging.getLogger('relengapi')
+        n.setLevel(_relengapi_log_lvl)
+        n.debug("Setting relengapi logger to %s", _relengapi_log_lvl)
+
+after_setup_logger.connect(after_setup_logger_handler)


### PR DESCRIPTION
I had a desire to use debug logging for celery for relengapi, but I wanted it without the added global debugging (using `celery worker --loglevel debug` adds loads of other output)  (my current solution has been `print` which is sub-par)

Basically I just wanted relengapi.* to log in debug mode.  I got the general idea for this approach from http://www.toforge.com/2011/06/celery-centralized-logging/

The structure of it stemmed mostly from needed to have the signal setup before celery fully instantiates (calls its signals), but after the relengapi app is setup, and in a spot that the signal can actually access the app.

This code would need docs and test(s) if it was to be merged in, but I wanted a :+1: for the general idea first.  @djmitche or @mrrrgn . What do you think?