### PR TITLE
prohibit open redirects

### DIFF
--- a/docs/development/@relengapi/index.rst
+++ b/docs/development/@relengapi/index.rst
@@ -15,3 +15,4 @@
     badpenny
     aws
     memcached
+    safety

--- a/docs/development/@relengapi/safety.rst
+++ b/docs/development/@relengapi/safety.rst
@@ -1,0 +1,26 @@
+Safety Utilities
+================
+
+.. py:module:: relengapi.lib.safety
+
+RelengAPI is a security-sensitive application, so it's important to avoid common mistakes.
+While Werkzeug provides some utilities to help, this module supplements those with a few RelengAPI-specific tools.
+
+Redirect URLs
+-------------
+
+RelengAPI must not expose any "open redirects", URLs which could result in an HTTP redirect with a URL of a attacker's choosing.
+To avoid this, it is safest to not redirect to a URL provided by the user agent.
+However, sometimes such redirects are convenient, especially after authentication.
+In these cases, the next best approach is to refuse any redirects outside of the RelengAPI service itself.
+
+.. py:function:: safe_redirect_path(url)
+
+    :param url: the potentially dangerous URL
+    :returns: a URL guaranteed to be within the RelengAPI service
+
+    This method will return a relative path unchanged.
+    For URLs with a network location or schema, it will return a path to the root of the RelengAPI service.
+    Use it like this::
+
+        return redirect(safe_redirect_path(url_from_user_agent))

--- a/relengapi/lib/auth/__init__.py
+++ b/relengapi/lib/auth/__init__.py
@@ -17,6 +17,7 @@ from flask.ext.login import LoginManager
 from flask.ext.login import current_user
 from flask.ext.login import user_logged_in
 from flask.ext.login import user_logged_out
+from relengapi.lib import safety
 from relengapi.lib.permissions import p
 
 
@@ -127,7 +128,7 @@ def login_request():
     """Redirect here to ask the user to authenticate"""
     if current_user.is_authenticated():
         next_url = request.args.get('next') or url_for('root')
-        return redirect(next_url)
+        return redirect(safety.safe_redirect_path(next_url))
     return render_template("login_request.html")
 
 

--- a/relengapi/lib/auth/external.py
+++ b/relengapi/lib/auth/external.py
@@ -11,6 +11,7 @@ from flask import url_for
 from flask.ext.login import login_user
 from flask.ext.login import logout_user
 from relengapi.lib import auth
+from relengapi.lib import safety
 
 logger = logging.getLogger(__name__)
 
@@ -48,4 +49,4 @@ def init_app(app):
             return 'ok'
         # this was from the browser, so send them somewhere useful
         next_url = request.args.get('next') or url_for('root')
-        return redirect(next_url)
+        return redirect(safety.safe_redirect_path(next_url))

--- a/relengapi/lib/safety.py
+++ b/relengapi/lib/safety.py
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import urlparse
+
+from flask import url_for
+
+
+def safe_redirect_path(url):
+    parts = urlparse.urlparse(url)
+    if parts.scheme or parts.netloc:
+        return url_for('root')
+    # note that Werkzeug takes care of making redirect URLs absolute,
+    # so there's no need to do so here.
+    return url

--- a/relengapi/tests/test_lib_safety.py
+++ b/relengapi/tests/test_lib_safety.py
@@ -1,0 +1,27 @@
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from nose.tools import eq_
+from relengapi.lib import safety
+from relengapi.lib.testing.context import TestContext
+
+testcontext = TestContext(reuse_app=True)
+
+
+def test_safe_redirect_path_unqualified():
+    """A redirect to an unqualified path is alloewd"""
+    eq_(safety.safe_redirect_path('/foo/bar'), '/foo/bar')
+
+
+@testcontext
+def test_safe_redirect_path_schema_rejected(app):
+    """A redirect to a URL with a schema is not allowed and defaults to root"""
+    with app.test_request_context():
+        eq_(safety.safe_redirect_path('file:///foo/bar'), '/')
+
+
+@testcontext
+def test_safe_redirect_path_netloc_rejected(app):
+    """A redirect to a URL with a netloc is not allowed and defaults to root"""
+    with app.test_request_context():
+        eq_(safety.safe_redirect_path('//myserver.com/foo/bar'), '/')


### PR DESCRIPTION
I'm open to other ideas for module name beyond 'safety'.  But I figure we'll end up with a half-dozen random utility functions, similar to [Werkzeug](http://werkzeug.pocoo.org/docs/0.10/utils/)