### PR TITLE
badpenny `cleanup_old_jobs` fails with integrity error

### DIFF
--- a/relengapi/blueprints/badpenny/cleanup.py
+++ b/relengapi/blueprints/badpenny/cleanup.py
@@ -27,6 +27,8 @@ def cleanup_old_jobs(job_status):
         jobs = reversed(task.jobs[1:])
         for job in jobs:
             if job.created_at < old:
+                for log in job.logs:
+                    session.delete(log)
                 session.delete(job)
                 deleted += 1
 

--- a/relengapi/blueprints/badpenny/tables.py
+++ b/relengapi/blueprints/badpenny/tables.py
@@ -23,13 +23,18 @@ class BadpennyJob(db.declarative_base('relengapi')):
     __tablename__ = 'badpenny_jobs'
 
     id = sa.Column(sa.Integer, primary_key=True)
-    task_id = sa.Column(sa.Integer, sa.ForeignKey('badpenny_tasks.id'))
+    task_id = sa.Column(sa.Integer, sa.ForeignKey('badpenny_tasks.id'),
+                        nullable=False)
     task = sa.orm.relationship('BadpennyTask')
 
     created_at = sa.Column(db.UTCDateTime(timezone=True), nullable=False)
     started_at = sa.Column(db.UTCDateTime(timezone=True), nullable=True)
     completed_at = sa.Column(db.UTCDateTime(timezone=True), nullable=True)
     successful = sa.Column(sa.Boolean())
+
+    # note that there's never more than one log due to the unique id, but
+    # SQLAlchemy still models it as a list
+    logs = sa.orm.relationship('BadpennyJobLog')
 
     def to_jsonjob(self):
         return rest.BadpennyJob(id=self.id,

--- a/relengapi/blueprints/badpenny/test_badpenny.py
+++ b/relengapi/blueprints/badpenny/test_badpenny.py
@@ -22,8 +22,7 @@ from relengapi.lib.testing.context import TestContext
 def dt(*args):
     return datetime.datetime(*args, tzinfo=pytz.UTC)
 
-test_context = TestContext(databases=['relengapi'],
-                           reuse_app=True)
+test_context = TestContext(databases=['relengapi'])
 
 
 def insert_job(app, task_id, created_at, **kwargs):
@@ -113,9 +112,12 @@ def add_data(app):
 
 def create_job(app):
     with app.app_context():
+        session = app.db.session('relengapi')
+        task = tables.BadpennyTask(id=10, name='test.task')
+        session.add(task)
         job = tables.BadpennyJob(task_id=10, created_at=dt(2014, 9, 16))
-        app.db.session('relengapi').add(job)
-        app.db.session('relengapi').commit()
+        session.add(job)
+        session.commit()
         return job.id
 
 

--- a/relengapi/blueprints/badpenny/test_badpenny.py
+++ b/relengapi/blueprints/badpenny/test_badpenny.py
@@ -526,13 +526,17 @@ def test_cleanup(app):
         task = tables.BadpennyTask(name='foo')
         session.add(task)
 
-        def newjob(id, created_at):
-            task.jobs.append(tables.BadpennyJob(
-                id=id, task_id=task.id, created_at=created_at))
+        def newjob(id, created_at, log=None):
+            job = tables.BadpennyJob(
+                id=id, task=task, created_at=created_at)
+            session.add(job)
+            if log:
+                session.add(tables.BadpennyJobLog(id=id, content=log))
+
         newjob(1, dt(2014, 9, 20))
-        newjob(2, dt(2014, 9, 15))
+        newjob(2, dt(2014, 9, 15), log="Hello, world\n")
         newjob(3, dt(2014, 9, 10))
-        newjob(4, dt(2014, 9, 5))
+        newjob(4, dt(2014, 9, 5), log="Hello, world\n")
         session.commit()
         with mock.patch('relengapi.blueprints.badpenny.cleanup.time.now') as now:
             now.return_value = dt(2014, 9, 16)
@@ -540,3 +544,5 @@ def test_cleanup(app):
 
         eq_(sorted([j.id for j in tables.BadpennyJob.query.all()]),
             sorted([1, 2, 3]))  # 4 is gone
+        eq_(sorted([j.id for j in tables.BadpennyJobLog.query.all()]),
+            sorted([2]))  # log for 4 is gone

--- a/relengapi/blueprints/docs/test_docs.py
+++ b/relengapi/blueprints/docs/test_docs.py
@@ -29,7 +29,8 @@ def app_setup(app):
 
     # delete the srcdir, since we're running in development mode
     srcdir = os.path.join(sys.prefix, 'relengapi-docs')
-    shutil.rmtree(srcdir)
+    if os.path.exists(srcdir):
+        shutil.rmtree(srcdir)
 
     with app.app_context():
         args = mock.Mock()


### PR DESCRIPTION
```
IntegrityError: (raised as a result of Query-invoked autoflush; consider using a session.no_autoflush block if this flush is occurring prematurely) (IntegrityError) (1451, 'Cannot delete or update a parent row: a foreign key constraint fails (`relengapi`.`badpenny_job_logs`, CONSTRAINT `badpenny_job_logs_ibfk_1` FOREIGN KEY (`id`) REFERENCES `badpenny_jobs` (`id`))') 'DELETE FROM badpenny_jobs WHERE badpenny_jobs.id = %s' ((1235L,), (1238L,), (1240L,), (1243L,), (1245L,), (1248L,), (1250L,), (1253L,)  ... displaying 10 of 14 total bound parameter sets ...  (1265L,), (1268L,))
[2015-03-18 11:19:27,045: ERROR/Worker-2] Job 1276 failed
```