### PR TITLE
fix JS usage on chrome

### DIFF
--- a/relengapi/blueprints/tokenauth/static/tokens.js
+++ b/relengapi/blueprints/tokenauth/static/tokens.js
@@ -24,7 +24,7 @@ angular.module('tokens').controller('TokenController',
     });
 
     $scope.can = function(query_perm) {
-        return initial_data.user.permissions.find(function(perm) {
+        return initial_data.user.permissions.some(function(perm) {
             return perm.name == query_perm;
         });
     };

--- a/relengapi/static/js/relengapi.js
+++ b/relengapi/static/js/relengapi.js
@@ -69,7 +69,7 @@ angular.module('relengapi').provider('restapi', function() {
         return function() {
             var config;
             /* find the (possibly omitted) config argument */
-            var args = Array.slice(arguments);
+            var args = [].slice.apply(arguments);
             if (typeof args[0] === 'string') {
                 if (args.length < 2) {
                     args.push({});


### PR DESCRIPTION
It appears that `[].slice.apply` is the normal way to do this anyway.