### PR TITLE
SQS tests are flaky

### DIFF
--- a/relengapi/lib/aws.py
+++ b/relengapi/lib/aws.py
@@ -138,6 +138,8 @@ class AWS(object):
             while True:
                 time.sleep(2 ** 31)
 
+        return threads
+
 
 def init_app(app):
     app.aws = AWS(app.config.get('AWS', {}))


### PR DESCRIPTION
I wonder if there's some race condition with moto and the threading, where we sometimes make calls to the "real" SQS.  The bogus certificate in this error looks very strange, though.

```
Exception in thread us-east-1/'my-sqs-queue' -> <function listener at 0x7ffe0f72ec08>:

Traceback (most recent call last):

File "/opt/python/2.7.9/lib/python2.7/threading.py", line 810, in __bootstrap_inner

self.run()

File "/opt/python/2.7.9/lib/python2.7/threading.py", line 763, in run

self.__target(*self.__args, **self.__kwargs)

File "/home/travis/build/mozilla/build-relengapi/relengapi/lib/aws.py", line 92, in _listen_thd

msg = queue.read(wait_time_seconds=20, **read_args)

File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/boto/sqs/queue.py", line 208, in read

message_attributes=message_attributes)

File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/boto/sqs/queue.py", line 302, in get_messages

message_attributes=message_attributes)

File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/boto/sqs/connection.py", line 220, in receive_message

queue.id, queue)

File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/boto/connection.py", line 1169, in get_list

response = self.make_request(action, params, path, verb)

File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/boto/connection.py", line 1115, in make_request

return self._mexe(http_request)

File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/boto/connection.py", line 942, in _mexe

request.body, request.headers)

File "/opt/python/2.7.9/lib/python2.7/httplib.py", line 1001, in request

self._send_request(method, url, body, headers)

File "/opt/python/2.7.9/lib/python2.7/httplib.py", line 1035, in _send_request

self.endheaders(body)

File "/opt/python/2.7.9/lib/python2.7/httplib.py", line 997, in endheaders

self._send_output(message_body)

File "/opt/python/2.7.9/lib/python2.7/httplib.py", line 850, in _send_output

self.send(msg)

File "/opt/python/2.7.9/lib/python2.7/httplib.py", line 812, in send

self.connect()

File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/boto/https_connection.py", line 138, in connect

'certificate' % hostname)

InvalidCertificateException: Host queue.amazonaws.com returned an invalid certificate (remote hostname "queue.amazonaws.com" does not match certificate): {u'subject': (((u'organizationName', u'*.54.239.19.168'),), ((u'organizationalUnitName', u'Domain Control Validated'),), ((u'commonName', u'*.54.239.19.168'),)), u'subjectAltName': ((u'DNS', u'*54.239.19.168'), (u'DNS', '54.239.19.168'), (u'DNS', u'*')), u'notAfter': 'Feb 21 20:55:31 GMT'}

................................

======================================================================

ERROR: relengapi.tests.test_lib_aws.test_sqs_listen

----------------------------------------------------------------------

Traceback (most recent call last):

File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/nose/case.py", line 197, in runTest

self.test(*self.arg)

File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/moto/core/models.py", line 69, in wrapper

result = func(*args, **kwargs)

File "/home/travis/build/mozilla/build-relengapi/relengapi/lib/testing/context.py", line 98, in __call__

wrapped(*given_args, **kwargs)

File "/home/travis/build/mozilla/build-relengapi/relengapi/tests/test_lib_aws.py", line 126, in test_sqs_listen

app.aws.sqs_write('us-east-1', 'my-sqs-queue', 'BODY1')

File "/home/travis/build/mozilla/build-relengapi/relengapi/lib/aws.py", line 72, in sqs_write

queue.write(m)

File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/boto/sqs/queue.py", line 226, in write

message_attributes=message.message_attributes)

File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/boto/sqs/connection.py", line 331, in send_message

queue.id, verb='POST')

File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/boto/connection.py", line 1191, in get_object

response = self.make_request(action, params, path, verb)

File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/boto/connection.py", line 1115, in make_request

return self._mexe(http_request)

File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/boto/connection.py", line 943, in _mexe

response = connection.getresponse()

File "/opt/python/2.7.9/lib/python2.7/httplib.py", line 1071, in getresponse

response = self.response_class(*args, **kwds)

File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/boto/connection.py", line 390, in __init__

http_client.HTTPResponse.__init__(self, *args, **kwargs)

File "/opt/python/2.7.9/lib/python2.7/httplib.py", line 352, in __init__

self.fp = sock.makefile('rb', 0)

File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/httpretty/core.py", line 332, in makefile

self._entry.fill_filekind(self.fd)

File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/httpretty/core.py", line 591, in fill_filekind

status, headers, self.body = self.callable_body(self.request, self.info.full_url(), headers)

File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/moto/core/responses.py", line 124, in dispatch

return self.call_action()

File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/moto/core/responses.py", line 140, in call_action

response = method()

File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/moto/sqs/responses.py", line 103, in send_message

message = self.querystring.get("MessageBody")[0]

TypeError: 'NoneType' object has no attribute '__getitem__'

-------------------- >> begin captured logging << --------------------

sqlalchemy.engine.base.Engine: INFO: SELECT CAST('test plain returns' AS VARCHAR(60)) AS anon_1

sqlalchemy.engine.base.Engine: INFO: ()

sqlalchemy.engine.base.Engine: INFO: SELECT CAST('test unicode returns' AS VARCHAR(60)) AS anon_1

sqlalchemy.engine.base.Engine: INFO: ()

sqlalchemy.engine.base.Engine: INFO: PRAGMA table_info("sphinx_nodes")

sqlalchemy.engine.base.Engine: INFO: ()

sqlalchemy.engine.base.Engine: INFO: PRAGMA table_info("sphinx_comments")

sqlalchemy.engine.base.Engine: INFO: ()

sqlalchemy.engine.base.Engine: INFO: PRAGMA table_info("sphinx_commentvote")

sqlalchemy.engine.base.Engine: INFO: ()

relengapi.lib.aws: INFO: Listening to SQS queue 'my-sqs-queue' in region us-east-1

--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------

Ran 243 tests in 26.607s
```