### PR TITLE
session cleanup under celery fails

### DIFF
--- a/relengapi/lib/celery.py
+++ b/relengapi/lib/celery.py
@@ -22,7 +22,12 @@ def make_celery(app):
 
         def __call__(self, *args, **kwargs):
             with app.app_context():
-                return TaskBase.__call__(self, *args, **kwargs)
+                try:
+                    return TaskBase.__call__(self, *args, **kwargs)
+                finally:
+                    # flush any open DB sessions used by this task
+                    current_app.db.flush_sessions()
+
     celery.Task = ContextTask
     app.celery_tasks = dict((fn, celery.task(**kwargs)(fn))
                             for (fn, kwargs) in _defined_tasks.iteritems())

--- a/relengapi/lib/db.py
+++ b/relengapi/lib/db.py
@@ -10,7 +10,6 @@ import pytz
 import sqlalchemy as sa
 import threading
 
-from celery import signals
 from flask import current_app
 from relengapi.util import synchronized
 from sqlalchemy import event
@@ -141,12 +140,6 @@ def ping_connection(dbapi_connection, connection_record, connection_proxy):
         # connecting again up to three times before raising.
         raise exc.DisconnectionError()
     cursor.close()
-
-
-@signals.task_postrun.connect
-def task_postrun(sender=None, body=None, **kwargs):
-    # flush DB sessions after every celery task
-    current_app.db.flush_sessions()
 
 
 def make_db(app):


### PR DESCRIPTION
After #193:

```
[2015-03-26 13:02:08,076: CRITICAL/MainProcess] Task relengapi.blueprints.tooltool.grooming.check_file_pending_uploads[0a10970e-cb66-4a2d-a5ff-d081ab51b96a] INTERNAL ERROR: RuntimeError('working outside of application context',)
Traceback (most recent call last):
  File "/home/dustin/code/relengapi/t/tooltool/sandbox/lib/python2.7/site-packages/celery/app/trace.py", line 306, in trace_task
    retval=retval, state=state)
  File "/home/dustin/code/relengapi/t/tooltool/sandbox/lib/python2.7/site-packages/celery/utils/dispatch/signal.py", line 166, in send
    response = receiver(signal=self, sender=sender, **named)
  File "/home/dustin/code/relengapi/t/relengapi/relengapi/lib/db.py", line 149, in task_postrun
    current_app.db.flush_sessions()
  File "/home/dustin/code/relengapi/t/tooltool/sandbox/lib/python2.7/site-packages/werkzeug/local.py", line 338, in __getattr__
    return getattr(self._get_current_object(), name)
  File "/home/dustin/code/relengapi/t/tooltool/sandbox/lib/python2.7/site-packages/werkzeug/local.py", line 297, in _get_current_object
    return self.__local()
  File "/home/dustin/code/relengapi/t/tooltool/sandbox/lib/python2.7/site-packages/flask/globals.py", line 34, in _find_app
    raise RuntimeError('working outside of application context')
RuntimeError: working outside of application context
```