### PR TITLE
data truncated for datetime columns

### DIFF
--- a/docs/relnotes/2.0.0.rst
+++ b/docs/relnotes/2.0.0.rst
@@ -17,6 +17,8 @@ Breaking Changes
   * ``user``
   * ``disabled``
 
+* The ``badpenny_jobs`` table's ``task_id`` column is no longer nullable.
+
 * Previous versions of RelengAPI mistakenly expected a header named ``Authentication`` instead of the standard ``Authorization``.
   In this version of RelengAPI, both are accepted, but clients should switch to use the correct, standard header.
   Support for ``Authentication`` will be dropped in relengapi-3.0.0

--- a/relengapi/lib/db.py
+++ b/relengapi/lib/db.py
@@ -157,7 +157,7 @@ class UTCDateTime(types.TypeDecorator):
             # to a naive Python datetime.  Passing it a tz-aware datetime
             # causes a warning ("Out of range value for column .."), so we make
             # it naive.
-            if dialect == 'mysql':
+            if dialect.name == 'mysql':
                 value = value.replace(tzinfo=None)
         # else assume UTC
         return value


### PR DESCRIPTION
When running badpenny tasks and updating the job rows:
```
[2015-03-27 18:22:29,935: WARNING/Worker-1] /home/dustin/code/relengapi/t/tooltool/sandbox/lib/python2.7/site-packages/sqlalchemy/engine/default.py:436: Warning: Data truncated for column 'started_at' at row 1
  cursor.execute(statement, parameters)
[2015-03-27 18:22:29,940: WARNING/Worker-2] /home/dustin/code/relengapi/t/tooltool/sandbox/lib/python2.7/site-packages/sqlalchemy/engine/default.py:436: Warning: Data truncated for column 'started_at' at row 1
  cursor.execute(statement, parameters)
[2015-03-27 18:22:29,980: WARNING/Worker-2] /home/dustin/code/relengapi/t/tooltool/sandbox/lib/python2.7/site-packages/sqlalchemy/engine/default.py:436: Warning: Data truncated for column 'completed_at' at row 1
  cursor.execute(statement, parameters)
[2015-03-27 18:22:29,996: WARNING/Worker-1] /home/dustin/code/relengapi/t/tooltool/sandbox/lib/python2.7/site-packages/sqlalchemy/engine/default.py:436: Warning: Data truncated for column 'completed_at' at row 1
```