### PR TITLE
wsgi/Werkzeug/Flask handle the 'Authorization' header

### DIFF
--- a/docs/deployment/@relengapi/environment.rst
+++ b/docs/deployment/@relengapi/environment.rst
@@ -47,3 +47,6 @@ The Mozilla deployment of RelengAPI has a WSGI file that looks like this::
     os.environ['RELENGAPI_SETTINGS'] = os.path.join(this_dir, 'settings.py')
     application = create_app()
 
+RelengAPI processes the ``Authorization`` header on its own to handle token authentication.
+However, mod_wsgi filters this header out by default.
+To fix this, set ``WSGIPassAuthorization On`` in your Apache configuration.

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     url='https://api.pub.build.mozilla.org',
     install_requires=[
         "Flask",
-        "Flask-Login>=0.2.10",
+        "Flask-Login>=0.2.11",
         "Flask-Browserid",
         "Sphinx",
         "SQLAlchemy>=0.9.4",


### PR DESCRIPTION
If you actually send "Authorization: foo" over HTTP, it doesn't make it to the server the way the tests suggest.