### PR TITLE
Bug 1151636: ignore results for badpenny tasks

### DIFF
--- a/relengapi/blueprints/badpenny/execution.py
+++ b/relengapi/blueprints/badpenny/execution.py
@@ -47,7 +47,7 @@ class JobStatus(object):
         session.commit()
 
 
-@celery.task()
+@celery.task(ignore_result=True)
 def _run_job(task_name, job_id):
     task = badpenny.Task.get(task_name)
     if not task:


### PR DESCRIPTION
This avoids creating a lot of result queues that serve no purpose.