### PR TITLE
allow RELENGAPI_SETTINGS to be relative to the current directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,8 @@ python:
 
 env:
   # the 'relengapi' command wants a settings file, but the contents
-  # aren't terribly important, so the example will do fine.  This is
-  # relative to the directory containing app.py, although Flask does not
-  # document that.
-  - RELENGAPI_SETTINGS=../settings_example.py
+  # aren't terribly important, so the example will do fine
+  - RELENGAPI_SETTINGS=settings_example.py
 
 # command to install dependencies
 install:

--- a/relengapi/lib/subcommands.py
+++ b/relengapi/lib/subcommands.py
@@ -4,6 +4,7 @@
 
 import argparse
 import logging.handlers
+import os
 import pkg_resources
 import relengapi.app
 import sys
@@ -56,6 +57,13 @@ def main(args=None):
 
     if args._subcommand and args._subcommand.want_logging:
         setupConsoleLogging(args.quiet)
+
+    # make the RELENGAPI_SETTINGS env var an absolute path; without this, Flask
+    # uses the application's root_dir, which isn't especially helpful in a
+    # development context.
+    var_name = 'RELENGAPI_SETTINGS'
+    if var_name in os.environ:
+        os.environ[var_name] = os.path.abspath(os.environ[var_name])
 
     app = relengapi.app.create_app(cmdline=True)
     with app.app_context():


### PR DESCRIPTION
Without this, I have to manually set RELENGAPI_SETTINGS when I switch between blueprints (tooltool vs. clobberer vs. relengapi).  With this, I can just set it to `settings.py` and it will use that file in the cwd.

r?