### PR TITLE
Improve the <perm> directive to describe permissions in a tooltip

### DIFF
--- a/docs/development/@relengapi/web-ui.rst
+++ b/docs/development/@relengapi/web-ui.rst
@@ -172,7 +172,7 @@ The Python code to render an Angular template faintly resembles normal Flask cod
     Render an HTML page containing the named template in its ``content`` block.
     All of the dependency URLs are loaded in the ``<head>`` element.
     Any keyword arguments are JSONified and passed to the Angular app in the ``initial_data`` module.
-    To use this data, depend on the module, and then inject ``initial_data``; see the example above.
+    To use this data, depend on the module, and then inject ``initial_data``; see the example below.
 
 The named template must contain an element with an ``ng-app`` attribute specifying a module of your devising, or Angular will do nothing.
 Inside of that element, the Angular documentation applies as usual.
@@ -182,6 +182,11 @@ Javascript best practices suggest supplying initial data for a page along with t
 The ``initial_data`` arguments, Angular module, and Angular constant make this easy.
 However, it's important that this data also be available via an API call.
 The most common way to accomplish this is to invoke the actual API call using :py:func:`~relengapi.lib.api.get_data`.
+
+The ``initial_data`` constant contains the following data in every template:
+
+    * ``initial_data.user`` -- the current user
+    * ``initial_data.perms`` -- all defined permissions, in the form of a map from permission name to permission documentation.
 
 Putting all of this together::
 
@@ -216,7 +221,7 @@ Angular Directives
 
 The following directives are available in any Angular template that requires the ``relengapi`` module:
 
- * ``<perm>foo.bar</perm>`` -- renders a permission name
+ * ``<perm name="foo.bar" />`` -- renders a permission name
 
 Angular Services
 ................

--- a/relengapi/blueprints/auth/static/account.html
+++ b/relengapi/blueprints/auth/static/account.html
@@ -17,7 +17,7 @@
     <div ng-show="initial_data.user.permissions">
       <ul>
       <li ng-repeat="perm in initial_data.user.permissions">
-        <span class="permission">{{perm.name}}</span> - <span class="action-docstring">{{perm.doc}}</span></li>
+      <perm name="{{perm.name}}"></perm> - <span class="action-docstring">{{perm.doc}}</span></li>
       </ul>
     </div>
     <div ng-hide="initial_data.user.permissions">

--- a/relengapi/blueprints/auth/static/account.js
+++ b/relengapi/blueprints/auth/static/account.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-angular.module('auth', ['initial_data']);
+angular.module('auth', ['initial_data', 'relengapi']);
 
 angular.module('auth').controller('AuthController',
                                   function($scope, initial_data) {

--- a/relengapi/blueprints/tokenauth/static/permissionSelector.html
+++ b/relengapi/blueprints/tokenauth/static/permissionSelector.html
@@ -10,7 +10,7 @@
         ng-class="{'success': permissions.indexOf(perm.name) != -1}"
         ng-click="togglePermission(perm)">
         </td><td>
-            <perm>{{perm.name}}</perm>
+            <perm name="{{perm.name}}" />
         </td><td>
             <small>{{perm.doc}}</small>
         </td>

--- a/relengapi/blueprints/tokenauth/static/tokens.html
+++ b/relengapi/blueprints/tokenauth/static/tokens.html
@@ -34,7 +34,7 @@
                         </small>
                         <br />
                         <span ng-repeat="perm in token.permissions">
-                            <perm>{{perm}}</perm>
+                            <perm name="{{perm}}" />
                         </span>
                     </div>
                     <div class="col-sm-2">

--- a/relengapi/lib/angular.py
+++ b/relengapi/lib/angular.py
@@ -9,6 +9,7 @@ from flask import render_template
 from flask import request
 from flask import url_for
 from flask.ext.login import current_user
+from relengapi import p
 from relengapi.lib import permissions
 
 
@@ -32,12 +33,15 @@ def template(template_name, *dependency_urls, **initial_data):
 
     # include info on the current user
     user = {}
-    user['permissions'] = [permissions.JsonPermission(name='.'.join(p), doc=p.__doc__)
-                           for p in current_user.permissions]
+    user['permissions'] = [permissions.JsonPermission(name='.'.join(prm), doc=prm.__doc__)
+                           for prm in current_user.permissions]
     user['type'] = current_user.type
     if current_user.type == 'human':
         user['authenticated_email'] = current_user.authenticated_email
     initial_data['user'] = user
+
+    # include the full list of available permissions
+    initial_data['perms'] = {str(prm): doc for prm, doc in p}
 
     return render_template('angular.html',
                            template=template,

--- a/relengapi/lib/permissions.py
+++ b/relengapi/lib/permissions.py
@@ -47,6 +47,9 @@ class Permissions(Permission):
             index = tuple(index.split('.'))
         return self._all[index]
 
+    def __iter__(self):
+        return ((prm, prm.__doc__) for prm in self._all.itervalues())
+
     def get(self, index, default=None):
         try:
             return self[index]

--- a/relengapi/static/js/relengapi.js
+++ b/relengapi/static/js/relengapi.js
@@ -100,13 +100,24 @@ angular.module('relengapi').provider('restapi', function() {
     };
 });
 
-angular.module('relengapi').directive('perm', function() {
+angular.module('relengapi').directive('perm', function(initial_data) {
     return {
         restrict: 'E',
-        transclude: true,
-        template: function(elem, attr) {
+        replace: true,
+        scope: {
+            'name': '@'
+        },
+        template: 
             // note the trailing space!
-            return '<span class="label label-info" ng-transclude></span> ';
+            '<span class="label label-info" ' +
+                  'data-toggle="tooltip" data-placement="top" >{{name}}</span> ',
+        link: function(scope, elt) {
+            elt.tooltip({
+                delay: 250,
+                title: function() {
+                    return initial_data.perms[scope.name];
+                },
+            });
         }
     };
 });

--- a/relengapi/tests/test_lib_permissions.py
+++ b/relengapi/tests/test_lib_permissions.py
@@ -47,6 +47,11 @@ def test_Permission_undoc_KeyError():
     assert_raises(KeyError, lambda: perms['a.b.never_mentioned'])
 
 
+def test_Permission_iter():
+    permissions.p.x.y.doc("XY")
+    assert (('x', 'y'), 'XY') in list(permissions.p)
+
+
 class TestUser(auth.BaseUser):
 
     anonymous = False


### PR DESCRIPTION
If you hover over a permission anywhere in the Releng API UI, it should give you the description for that permission.

This will require adding an endpoint that describes permissions (probably in the `auth` blueprint), then calling that appropriately from Angular code.