### PR TITLE
On token generation page, "issue" button should be disabled, not hidden

### DIFF
--- a/relengapi/blueprints/tokenauth/__init__.py
+++ b/relengapi/blueprints/tokenauth/__init__.py
@@ -124,6 +124,7 @@ def can_access_token(access, typ, user):
 def root():
     return angular.template('tokens.html',
                             url_for('.static', filename='tokens.js'),
+                            url_for('.static', filename='tokens.css'),
                             tokens=api.get_data(list_tokens))
 
 

--- a/relengapi/blueprints/tokenauth/static/tokens.css
+++ b/relengapi/blueprints/tokenauth/static/tokens.css
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+pre.token {
+    font-size: 80%;
+}

--- a/relengapi/blueprints/tokenauth/static/tokens.html
+++ b/relengapi/blueprints/tokenauth/static/tokens.html
@@ -75,7 +75,7 @@
                         <input ng-model="newtoken.description" ng-required="true" class="form-control"
                             placeholder="Bug 1234567: Frobnicator access to update and delete frobs" />
                         <button class="btn btn-primary btn-block"
-                                ng-hide="form.$invalid"
+                                ng-disabled="form.$invalid"
                                 ng-click="issueToken()">Issue</button>
                     </form>
                 </div>


### PR DESCRIPTION
Mostly a new user issue - it's not obvious that to issue a token, the description must be non-empty.
Having the "issue" button visible, but disabled, would suggest that something more needs to be done.