### PR TITLE
Format user tokens better

### DIFF
--- a/relengapi/blueprints/tokenauth/loader.py
+++ b/relengapi/blueprints/tokenauth/loader.py
@@ -26,8 +26,14 @@ class TokenUser(auth.BaseUser):
             self.authenticated_email = authenticated_email
 
     def get_id(self):
-        jti = (':' + self.claims['jti']) if 'jti' in self.claims else ''
-        return 'token:%s%s' % (self.claims['typ'], jti)
+        parts = ['token', self.claims['typ']]
+        if 'jti' in self.claims:
+            parts.append('id={}'.format(self.claims['jti']))
+        try:
+            parts.append('user={}'.format(self.authenticated_email))
+        except AttributeError:
+            pass
+        return ':'.join(parts)
 
     def get_permissions(self):
         return self._permissions

--- a/relengapi/blueprints/tokenauth/test_loader.py
+++ b/relengapi/blueprints/tokenauth/test_loader.py
@@ -15,6 +15,22 @@ from relengapi.blueprints.tokenauth.util import insert_prm
 from relengapi.blueprints.tokenauth.util import insert_usr
 
 
+def test_TokenUser_str_tmp():
+    tu = loader.TokenUser({'typ': 'tmp', 'mta': '{}'})
+    eq_(str(tu), 'token:tmp')
+
+
+def test_TokenUser_str_usr():
+    tu = loader.TokenUser({'typ': 'usr', 'jti': '13'},
+                          authenticated_email='foo@bar.com')
+    eq_(str(tu), 'token:usr:id=13:user=foo@bar.com')
+
+
+def test_TokenUser_str_prm():
+    tu = loader.TokenUser({'typ': 'prm', 'jti': '13'})
+    eq_(str(tu), 'token:prm:id=13')
+
+
 @test_context
 def test_loader_no_header(app, client):
     """With no Authorization header, no permissions are allowed"""


### PR DESCRIPTION
When authenticating with a token, str(current_user) contains only the token ID, which doesn't indicate *whose* token it is.  That info should be readily avaliable, and would make logging a lot more helpful!