### PR TITLE
Add req of Sphinx>=1.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "Flask",
         "Flask-Login>=0.2.11",
         "Flask-Browserid",
-        "Sphinx",
+        "Sphinx>=1.3",
         "SQLAlchemy>=0.9.4",
         "Celery>=3.1.16",  # see https://github.com/mozilla/build-relengapi/issues/145
         "argparse",


### PR DESCRIPTION
PR #194 broke upgrade attempts due to the lack of a hint to upgrade Sphinx.

In manual testing Sphinx 1.3 is enough to get past the error:
```sphinx.errors.ThemeError: no theme named 'classic' found (missing theme.conf?)```