### PR TITLE
When !can_view and !can_issue, tokenauth view should show *something*

### DIFF
--- a/relengapi/blueprints/tokenauth/static/tokens.html
+++ b/relengapi/blueprints/tokenauth/static/tokens.html
@@ -101,5 +101,13 @@
                 </div>
             </div>
         </div>
+        <div ng-controller="TokenListController"
+            class="col-xs-12"
+            ng-show="!can_view && !can_issue">
+            <div class="alert alert-danger"><b>Can't Do Much!</b>
+                You can't see or issue tokens.
+                If you think this is incorrect, head to #releng for help.
+            </div>
+        </div>
     </div>
 </div>

--- a/relengapi/templates/login_request.html
+++ b/relengapi/templates/login_request.html
@@ -3,5 +3,6 @@
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 {% extends "layout.html" %}
 {% block content %}
-  <p class="bg-danger">A valid login is required.  Please login (above) to proceed.</p>
+<div class="alert alert-danger"><b>A valid login is required.</b>
+    Please login (above) to proceed.</p>
 {% endblock %}


### PR DESCRIPTION
As it is, if you can't issue or view tokens, you get a big 'ol blank screen, which leads to lots of "[what browser version are you using](https://bugzilla.mozilla.org/show_bug.cgi?id=1162556)" kind of debugging.