### PR TITLE
Use structlog for relengapi logging

### DIFF
--- a/relengapi/app.py
+++ b/relengapi/app.py
@@ -149,8 +149,8 @@ def create_app(cmdline=False, test_config=None):
         # reset the logging context, deleting any info for the previous request
         # in this thread and binding new
         relengapi_logging.reset_context(
-                request_id=g.request_id,
-                user=str(current_user))
+            request_id=g.request_id,
+            user=str(current_user))
 
     @app.route('/')
     def root():
@@ -167,6 +167,8 @@ def create_app(cmdline=False, test_config=None):
     @api.apimethod(VersionInfo)
     def versions():
         dists = {}
+        log = logger.bind(frobnication_id='12345', permissions=['frob', 'blob'])
+        log.warning("frobnication failed")
         for dist in introspection.get_distributions().itervalues():
             dists[dist.key] = DistributionInfo(
                 project_name=dist.project_name,

--- a/relengapi/app.py
+++ b/relengapi/app.py
@@ -13,6 +13,7 @@ from flask import Flask
 from flask import g
 from flask import render_template
 from flask import request
+from flask.ext.login import current_user
 from relengapi.lib import api
 from relengapi.lib import auth
 from relengapi.lib import aws
@@ -147,7 +148,9 @@ def create_app(cmdline=False, test_config=None):
 
         # reset the logging context, deleting any info for the previous request
         # in this thread and binding new
-        relengapi_logging.reset_context(request_id=g.request_id)
+        relengapi_logging.reset_context(
+                request_id=g.request_id,
+                user=str(current_user))
 
     @app.route('/')
     def root():

--- a/relengapi/blueprints/archiver/__init__.py
+++ b/relengapi/blueprints/archiver/__init__.py
@@ -31,14 +31,16 @@ FINISHED_STATES = ['SUCCESS', 'FAILURE', 'REVOKED']
 
 def delete_tracker(tracker):
     session = current_app.db.session('relengapi')
-    logger.info("deleting tracker with id: {}".format(tracker.task_id))
+    logger.info("deleting tracker with id: {}".format(tracker.task_id),
+                archiver_task=tracker.task_id)
     session.delete(tracker)
     session.commit()
 
 
 def update_tracker_state(tracker, state):
     session = current_app.db.session('relengapi')
-    logger.info("updating tracker with id: {} to state: {}".format(tracker.id, state))
+    logger.info("updating tracker with id: {} to state: {}".format(tracker.id, state),
+                archiver_task=tracker.task_id, archiver_task_state=state)
     try:
         tracker.state = state
         session.commit()
@@ -62,7 +64,8 @@ def cleanup_old_tasks(job_status):
 def renew_tracker_pending_expiry(tracker):
     pending_expires_at = now() + datetime.timedelta(seconds=PENDING_EXPIRES_IN)
     session = current_app.db.session('relengapi')
-    log.info("renewing tracker {} with pending expiry: {}".format(tracker.id, pending_expires_at))
+    logger.info("renewing tracker {} with pending expiry: {}".format(
+                tracker.id, pending_expires_at), archiver_task=tracker.task_id)
     tracker.pending_expires_at = pending_expires_at
     session.commit()
 

--- a/relengapi/blueprints/archiver/__init__.py
+++ b/relengapi/blueprints/archiver/__init__.py
@@ -2,11 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import logging
-
-
 import datetime
 import sqlalchemy as sa
+import structlog
 
 from random import randint
 
@@ -24,7 +22,7 @@ from relengapi.lib import badpenny
 from relengapi.lib.time import now
 
 bp = Blueprint('archiver', __name__)
-log = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 GET_EXPIRES_IN = 300
 PENDING_EXPIRES_IN = 60
@@ -33,14 +31,14 @@ FINISHED_STATES = ['SUCCESS', 'FAILURE', 'REVOKED']
 
 def delete_tracker(tracker):
     session = current_app.db.session('relengapi')
-    log.info("deleting tracker with id: {}".format(tracker.task_id))
+    logger.info("deleting tracker with id: {}".format(tracker.task_id))
     session.delete(tracker)
     session.commit()
 
 
 def update_tracker_state(tracker, state):
     session = current_app.db.session('relengapi')
-    log.info("updating tracker with id: {} to state: {}".format(tracker.id, state))
+    logger.info("updating tracker with id: {} to state: {}".format(tracker.id, state))
     try:
         tracker.state = state
         session.commit()
@@ -86,6 +84,7 @@ def task_status(task_id):
     """
     task = create_and_upload_archive.AsyncResult(task_id)
     task_tracker = tables.ArchiverTask.query.filter(tables.ArchiverTask.task_id == task_id).first()
+    log = logger.bind(archiver_task=task_id, archiver_task_state=task.state)
     log.info("checking status of task id {}: current state {}".format(task_id, task.state))
     task_info = task.info or {}
     response = {
@@ -180,12 +179,14 @@ def get_archive(src_url, key, preferred_region):
         # because we want to know when the row doesn't exist before creating it
         tracker = tables.ArchiverTask.query.filter(tables.ArchiverTask.task_id == task_id).first()
         if tracker and tracker.state in FINISHED_STATES:
+            log = logger.bind(archiver_task=task_id, archiver_task_state=tracker.state)
             log.info('Task tracker: {} exists but finished with state: '
                      '{}'.format(task_id, tracker.state))
             # remove tracker and try celery task again
             delete_tracker(tracker)
             tracker = None
         if not tracker:
+            log = logger.bind(archiver_task=task_id)
             log.info("Creating new celery task and task tracker for: {}".format(task_id))
             task = create_and_upload_archive.apply_async(args=[src_url, key], task_id=task_id)
             if task and task.id:
@@ -198,7 +199,7 @@ def get_archive(src_url, key, preferred_region):
                 return {}, 500
         return {}, 202, {'Location': url_for('archiver.task_status', task_id=task_id)}
 
-    log.info("generating GET URL to {}, expires in {}s".format(key, GET_EXPIRES_IN))
+    logger.info("generating GET URL to {}, expires in {}s".format(key, GET_EXPIRES_IN))
     # return 302 pointing to s3 url with archive
     signed_url = s3.generate_url(
         method='GET', expires_in=GET_EXPIRES_IN,

--- a/relengapi/blueprints/badpenny/__init__.py
+++ b/relengapi/blueprints/badpenny/__init__.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import logging
+import structlog
 
 from flask import Blueprint
 from flask import current_app
@@ -20,7 +20,7 @@ from relengapi.lib import permissions
 from relengapi.lib import time
 from werkzeug.exceptions import NotFound
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 bp = Blueprint('badpenny', __name__,
                static_folder='static',
                template_folder='templates')

--- a/relengapi/blueprints/badpenny/cleanup.py
+++ b/relengapi/blueprints/badpenny/cleanup.py
@@ -3,14 +3,14 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import datetime
-import logging
+import structlog
 
 from flask import current_app
 from relengapi.blueprints.badpenny import tables
 from relengapi.lib import badpenny
 from relengapi.lib import time
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 
 @badpenny.periodic_task(seconds=24 * 3600)

--- a/relengapi/blueprints/badpenny/cron.py
+++ b/relengapi/blueprints/badpenny/cron.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import logging
+import structlog
 
 from flask import Blueprint
 from flask import current_app
@@ -13,7 +13,7 @@ from relengapi.lib import subcommands
 from relengapi.lib import time
 
 bp = Blueprint('base', __name__)
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 
 class BadpennyCron(subcommands.Subcommand):

--- a/relengapi/blueprints/badpenny/execution.py
+++ b/relengapi/blueprints/badpenny/execution.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import logging
+import structlog
 import traceback
 
 from flask import current_app
@@ -11,7 +11,7 @@ from relengapi.lib import badpenny
 from relengapi.lib import celery
 from relengapi.lib import time
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 
 def submit_job(task_name, job_id):

--- a/relengapi/blueprints/base/__init__.py
+++ b/relengapi/blueprints/base/__init__.py
@@ -4,6 +4,7 @@
 
 import logging
 import os
+import structlog
 import sys
 
 from flask import Blueprint
@@ -13,7 +14,7 @@ from flask import current_app
 from relengapi.lib import subcommands
 
 bp = Blueprint('base', __name__)
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 
 class ServeSubcommand(subcommands.Subcommand):

--- a/relengapi/blueprints/clobberer/__init__.py
+++ b/relengapi/blueprints/clobberer/__init__.py
@@ -4,7 +4,7 @@
 
 import collections
 import flask_login
-import logging
+import structlog
 import time
 
 import re
@@ -31,7 +31,7 @@ from relengapi import p
 from relengapi.lib import angular
 from relengapi.lib import api
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 bp = Blueprint(
     'clobberer',
@@ -191,7 +191,7 @@ def lastclobber_by_builder(branch):
     ).filter(
         Build.branch == branch,
         not_(Build.buildername.startswith(BUILDER_REL_PREFIX))
-        ).distinct().order_by(Build.buildername)
+    ).distinct().order_by(Build.buildername)
 
     summary = collections.defaultdict(list)
     for result in full_query:

--- a/relengapi/blueprints/docs/__init__.py
+++ b/relengapi/blueprints/docs/__init__.py
@@ -3,10 +3,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import StringIO
-import logging
 import os
 import pkg_resources
 import shutil
+import structlog
 
 from flask import Blueprint
 from flask import abort
@@ -17,7 +17,7 @@ from relengapi.lib import subcommands
 from sphinx.websupport import WebSupport
 from sphinx.websupport.errors import DocumentNotFoundError
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 bp = Blueprint('docs', __name__,
                template_folder='templates')

--- a/relengapi/blueprints/mapper/__init__.py
+++ b/relengapi/blueprints/mapper/__init__.py
@@ -4,9 +4,9 @@
 
 import calendar
 import dateutil.parser
-import logging
 import re
 import sqlalchemy as sa
+import structlog
 import time
 
 from flask import Blueprint
@@ -22,7 +22,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from relengapi import p
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 # logging.basicConfig(level=logging.DEBUG)
 bp = Blueprint('mapper', __name__)
 

--- a/relengapi/blueprints/mapper/test_mapper.py
+++ b/relengapi/blueprints/mapper/test_mapper.py
@@ -173,11 +173,11 @@ def test_get_mapfile_since(app, client):
 def test_insert_one(client):
     # TODO: this should really be POST
     with mock.patch('time.time') as time:
-        time.return_value = 1234.0
+        time.return_value = 1434378379.0
         rv = client.post('/mapper/proj/insert/%s/%s' % (SHA1, SHA2))
     eq_(rv.status_code, 200)
     eq_(json.loads(rv.data), {
-        'date_added': 1234.0,
+        'date_added': 1434378379.0,
         'project_name': 'proj',
         'git_commit': SHA1,
         'hg_changeset': SHA2,

--- a/relengapi/blueprints/slaveloan/__init__.py
+++ b/relengapi/blueprints/slaveloan/__init__.py
@@ -3,8 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import flask_login
-import logging
 import sqlalchemy as sa
+import structlog
 
 from sqlalchemy import asc
 
@@ -32,7 +32,7 @@ from relengapi.blueprints.slaveloan.model import Loans
 from relengapi.blueprints.slaveloan.model import Machines
 from relengapi.blueprints.slaveloan.model import ManualActions
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 bp = Blueprint('slaveloan', __name__,
                template_folder='templates',

--- a/relengapi/blueprints/slaveloan/bugzilla.py
+++ b/relengapi/blueprints/slaveloan/bugzilla.py
@@ -5,13 +5,13 @@
 # XXX Much of this functionality should probably be its own
 #     Separate relengapi blueprint
 
-import logging
+import structlog
 
 from bzrest.client import BugzillaClient
 from flask import current_app
 from flask import url_for
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger()
 
 MAX_ALIAS = 15
 DEFAULT_BUGZILLA_URL = "https://bugzilla-dev.allizom.org/rest/"

--- a/relengapi/blueprints/slaveloan/tasks.py
+++ b/relengapi/blueprints/slaveloan/tasks.py
@@ -25,9 +25,9 @@ from relengapi.lib.celery import task
 from relengapi.util import tz
 
 import celery
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 
 def add_task_to_history(loanid, msg):

--- a/relengapi/blueprints/tokenauth/__init__.py
+++ b/relengapi/blueprints/tokenauth/__init__.py
@@ -280,8 +280,12 @@ def issue_token(body):
     # Dispatch the rest to the per-type function.  Note that WSME has already
     # ensured `typ` is one of the recognized types.
     token = token_issuers[typ](body, requested_permissions)
-    logger.info("Issuing {} token #{} to {} with permissions {}".format(
-        token.typ, token.id or '(no ID)', current_user, requested_permissions))
+    perms_str = ', '.join(str(p) for p in requested_permissions)
+    log = logger.bind(token_typ=token.typ, token_permissions=perms_str)
+    if token.id:
+        log = log.bind(token_id=token.id)
+    log.info("Issuing {} token to {} with permissions {}".format(
+        token.typ, current_user, perms_str))
     return token
 
 
@@ -341,9 +345,11 @@ def revoke_token(token_id):
     if not can_access_token('revoke', token_data.typ, token_data.user):
         raise Forbidden
 
-    logger.info("Revoking {} token #{} with permissions {}".format(
-        token_data.typ, token_data.id,
-        ', '.join(str(p) for p in token_data.permissions)))
+    perms_str = ', '.join(str(p) for p in token_data.permissions)
+    log = logger.bind(token_typ=token_data.typ, token_permissions=perms_str,
+                      token_id=token_id)
+    log.info("Revoking {} token #{} with permissions {}".format(
+        token_data.typ, token_data.id, perms_str))
 
     tables.Token.query.filter_by(id=token_id).delete()
     session.commit()

--- a/relengapi/blueprints/tokenauth/__init__.py
+++ b/relengapi/blueprints/tokenauth/__init__.py
@@ -3,8 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import calendar
-import logging
 import sqlalchemy as sa
+import structlog
 import time
 import wsme
 
@@ -28,7 +28,7 @@ from werkzeug.exceptions import BadRequest
 from werkzeug.exceptions import Forbidden
 from werkzeug.exceptions import NotFound
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 bp = Blueprint('tokenauth', __name__,
                template_folder='templates',
                static_folder='static')

--- a/relengapi/blueprints/tokenauth/loader.py
+++ b/relengapi/blueprints/tokenauth/loader.py
@@ -92,10 +92,7 @@ class TokenLoader(object):
             typ_fn = self.type_functions[claims['typ']]
         except KeyError:
             return
-        user = typ_fn(claims)
-        if user:
-            logger.debug("Token access by %s", user)
-        return user
+        return typ_fn(claims)
 
 
 token_loader = TokenLoader()

--- a/relengapi/blueprints/tokenauth/loader.py
+++ b/relengapi/blueprints/tokenauth/loader.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import logging
+import structlog
 import time
 
 from relengapi import p
@@ -11,7 +11,7 @@ from relengapi.blueprints.tokenauth import tokenstr
 from relengapi.lib import auth
 from werkzeug.exceptions import BadRequest
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 
 class TokenUser(auth.BaseUser):

--- a/relengapi/blueprints/tokenauth/tokenstr.py
+++ b/relengapi/blueprints/tokenauth/tokenstr.py
@@ -2,14 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import logging
+import structlog
 
 from flask import current_app
 from itsdangerous import BadData
 from itsdangerous import JSONWebSignatureSerializer
 
 TOKENAUTH_ISSUER = 'ra2'
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 
 def init_app(app):

--- a/relengapi/blueprints/tokenauth/usermonitor.py
+++ b/relengapi/blueprints/tokenauth/usermonitor.py
@@ -28,18 +28,19 @@ def monitor_users(job_status):
             else:
                 disable = False
 
+        perm_str = ', '.join(str(p) for p in token.permissions)
+        log = logger.bind(token_typ=token.typ, token_id=token.id,
+                          token_user=token.user, token_permissions=perm_str)
         if disable and not token.disabled:
             logmsg = "Disabling {} token #{} for user {} with permissions {}".format(
-                token.typ, token.id, token.user,
-                ', '.join(str(p) for p in token.permissions))
-            logger.info(logmsg)
+                token.typ, token.id, token.user, perm_str)
+            log.info(logmsg)
             job_status.log_message(logmsg)
             token.disabled = True
         elif not disable and token.disabled:
             logmsg = "Re-enabling {} token #{} for user {} with permissions {}".format(
-                token.typ, token.id, token.user,
-                ', '.join(str(p) for p in token.permissions))
-            logger.info(logmsg)
+                token.typ, token.id, token.user, perm_str)
+            log.info(logmsg)
             job_status.log_message(logmsg)
             token.disabled = False
     session.commit()

--- a/relengapi/blueprints/tokenauth/usermonitor.py
+++ b/relengapi/blueprints/tokenauth/usermonitor.py
@@ -2,13 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import logging
+import structlog
 
 from flask import current_app
 from relengapi.blueprints.tokenauth import tables
 from relengapi.lib import badpenny
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 
 @badpenny.periodic_task(3600)

--- a/relengapi/blueprints/tooltool/__init__.py
+++ b/relengapi/blueprints/tooltool/__init__.py
@@ -149,6 +149,8 @@ def upload_batch(region=None, body=None):
 
     s3 = current_app.aws.connect_to('s3', region)
     for filename, info in body.files.iteritems():
+        log = logger.bind(tooltool_sha512=info.digest, tooltool_operation='upload',
+                          tooltool_batch_id=batch.id)
         if info.algorithm != 'sha512':
             raise BadRequest("'sha512' is the only allowed digest algorithm")
         if not is_valid_sha512(info.digest):
@@ -167,9 +169,8 @@ def upload_batch(region=None, body=None):
                     visibility=info.visibility,
                     size=info.size)
                 session.add(file)
-            logger.info("generating signed PUT URL to {} for {}, expires in {}s".format(
-                        info.digest, current_user, UPLOAD_EXPIRES_IN),
-                        tooltool_sha512=info.digest)
+            log.info("generating signed S3 PUT URL to {} for {}; expiring in {}s".format(
+                info.digest[:10], current_user, UPLOAD_EXPIRES_IN))
             info.put_url = s3.generate_url(
                 method='PUT', expires_in=UPLOAD_EXPIRES_IN, bucket=bucket,
                 key=util.keyname(info.digest),
@@ -312,6 +313,7 @@ def download_file(digest, region=None):
     The query argument ``region=us-west-1`` indicates a preference for a URL in
     that region, although if the file is not available in tht region then a URL
     from another region may be returned."""
+    log = logger.bind(tooltool_sha512=digest, tooltool_operation='download')
     if not is_valid_sha512(digest):
         raise BadRequest("Invalid sha512 digest")
 
@@ -342,9 +344,8 @@ def download_file(digest, region=None):
     key = util.keyname(digest)
 
     s3 = current_app.aws.connect_to('s3', selected_region)
-    logger.info("generating signed GET URL to {} for {}, expires in {}s".format(
-                digest, current_user, GET_EXPIRES_IN),
-                tooltool_sha512=digest)
+    log.info("generating signed S3 GET URL for {}.. expiring in {}s".format(
+        digest[:10], GET_EXPIRES_IN))
     signed_url = s3.generate_url(
         method='GET', expires_in=GET_EXPIRES_IN, bucket=bucket, key=key)
 

--- a/relengapi/blueprints/tooltool/__init__.py
+++ b/relengapi/blueprints/tooltool/__init__.py
@@ -53,7 +53,7 @@ p.tooltool.manage.doc("Manage tooltool files, including deleting and changing vi
 UPLOAD_EXPIRES_IN = 60
 GET_EXPIRES_IN = 60
 
-log = structlog.get_logger()
+logger = structlog.get_logger()
 
 
 def get_region_and_bucket(region_arg):
@@ -167,8 +167,9 @@ def upload_batch(region=None, body=None):
                     visibility=info.visibility,
                     size=info.size)
                 session.add(file)
-            log.info("generating signed PUT URL to {} for {}, expires in {}s".format(
-                     info.digest, current_user, UPLOAD_EXPIRES_IN))
+            logger.info("generating signed PUT URL to {} for {}, expires in {}s".format(
+                        info.digest, current_user, UPLOAD_EXPIRES_IN),
+                        tooltool_sha512=info.digest)
             info.put_url = s3.generate_url(
                 method='PUT', expires_in=UPLOAD_EXPIRES_IN, bucket=bucket,
                 key=util.keyname(info.digest),
@@ -341,8 +342,9 @@ def download_file(digest, region=None):
     key = util.keyname(digest)
 
     s3 = current_app.aws.connect_to('s3', selected_region)
-    log.info("generating signed GET URL to {} for {}, expires in {}s".format(
-             digest, current_user, GET_EXPIRES_IN))
+    logger.info("generating signed GET URL to {} for {}, expires in {}s".format(
+                digest, current_user, GET_EXPIRES_IN),
+                tooltool_sha512=digest)
     signed_url = s3.generate_url(
         method='GET', expires_in=GET_EXPIRES_IN, bucket=bucket, key=key)
 

--- a/relengapi/blueprints/tooltool/__init__.py
+++ b/relengapi/blueprints/tooltool/__init__.py
@@ -3,10 +3,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import datetime
-import logging
 import random
 import re
 import sqlalchemy as sa
+import structlog
 
 from flask import Blueprint
 from flask import current_app
@@ -53,7 +53,7 @@ p.tooltool.manage.doc("Manage tooltool files, including deleting and changing vi
 UPLOAD_EXPIRES_IN = 60
 GET_EXPIRES_IN = 60
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger()
 
 
 def get_region_and_bucket(region_arg):

--- a/relengapi/blueprints/tooltool/grooming.py
+++ b/relengapi/blueprints/tooltool/grooming.py
@@ -3,8 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import hashlib
-import logging
 import sqlalchemy as sa
+import structlog
 
 from datetime import timedelta
 from flask import current_app
@@ -14,7 +14,7 @@ from relengapi.lib import badpenny
 from relengapi.lib import celery
 from relengapi.lib import time
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger()
 
 
 @badpenny.periodic_task(seconds=600)

--- a/relengapi/cmd.py
+++ b/relengapi/cmd.py
@@ -3,26 +3,11 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import argparse
-import logging.handlers
 import os
 import relengapi.app
-import sys
 
 from relengapi.lib import subcommands
-
-
-def setupConsoleLogging(quiet):
-    root = logging.getLogger('')
-    if quiet:
-        root.setLevel(logging.WARNING)
-    else:
-        root.setLevel(logging.NOTSET)
-    formatter = logging.Formatter('%(asctime)s %(message)s')
-
-    stdout_log = logging.StreamHandler(sys.stdout)
-    stdout_log.setLevel(logging.DEBUG)
-    stdout_log.setFormatter(formatter)
-    root.addHandler(stdout_log)
+from relengapi.lib.logging import setupConsoleLogging
 
 
 def main(args=None):

--- a/relengapi/docs/deployment/environment.rst
+++ b/relengapi/docs/deployment/environment.rst
@@ -21,8 +21,8 @@ The Mozilla deployment of RelengAPI has a WSGI file that looks like this::
 
     # set up application logging
     import sys
-    import logging
-    import logging.handlers
+    import structlog
+    import structlog.handlers
 
     root = logging.getLogger('')
     root.setLevel(logging.NOTSET)

--- a/relengapi/docs/deployment/logging.rst
+++ b/relengapi/docs/deployment/logging.rst
@@ -71,3 +71,12 @@ To format log output as JSON, set the ``JSON_STRUCTURED_LOGGING`` setting to ``T
 
 Note, however, that logging output produced by non-RelengAPI code (e.g., Celery, SQLAlchemy) will not be JSON-formatted.
 Consumers must be able to accept non-JSON inputs.
+
+Request IDs
+-----------
+
+By default, RelengAPI will invent a "request ID" for each request it receives, and include that in all logging during the request handling.
+If you are deploying RelengAPI behind a load balancer or other service which has its own request IDs (such as Heroku's `HTTP Request IDs <https://devcenter.heroku.com/articles/http-request-id>`_), you can use those instead.
+Set ``REQUEST_ID_HEADER`` to the name of the header containing the request id; for example::
+
+    REQUEST_ID_HEADER = "X-Request-Id"

--- a/relengapi/docs/deployment/logging.rst
+++ b/relengapi/docs/deployment/logging.rst
@@ -62,3 +62,12 @@ One option is to replace the ``celery`` binary with a script of your own making 
     import sys
     from pkg_resources import load_entry_point
     ep = load_entry_point('celery', 'console_scripts', 'celery')
+
+Structured Logging
+------------------
+
+Releng API uses `structlog <https://structlog.readthedocs.org/>`_ internally to handle structrured log output.
+To format log output as JSON, set the ``JSON_STRUCTURED_LOGGING`` setting to ``True``.
+
+Note, however, that logging output produced by non-RelengAPI code (e.g., Celery, SQLAlchemy) will not be JSON-formatted.
+Consumers must be able to accept non-JSON inputs.

--- a/relengapi/docs/development/blueprints.rst
+++ b/relengapi/docs/development/blueprints.rst
@@ -24,12 +24,12 @@ Within ``__init__.py``, create a new blueprint::
     # License, v. 2.0. If a copy of the MPL was not distributed with this
     # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-    import logging
+    import structlog
 
     from flask import Blueprint
     from relengapi import apimethod
 
-    logger = logging.getLogger(__name__)
+    logger = structlog.get_logger()
     bp = Blueprint('bubbler', __name__,
                 static_folder='static',
                 template_folder='templates')

--- a/relengapi/docs/development/index.rst
+++ b/relengapi/docs/development/index.rst
@@ -15,6 +15,7 @@ This chapter is aimed at people hacking on RelengAPI itself and on RelengAPI Blu
     tasks
     auth
     tokenauth
+    logging
     utils
     app
     testing

--- a/relengapi/docs/development/logging.rst
+++ b/relengapi/docs/development/logging.rst
@@ -1,0 +1,11 @@
+Logging
+=======
+
+The Releng API uses `structlog <https://structlog.readthedocs.org/>`_ for logging.
+In practice this works almost exactly like the standard library's logging.
+At the top of each module, import ``structlog``, then create a global ``logger`` object::
+
+    logger = structlog.get_logger()
+
+This is sufficient for most cases.
+For more advanced uses, follow the ``structlog`` documentation.

--- a/relengapi/docs/development/utils.rst
+++ b/relengapi/docs/development/utils.rst
@@ -57,3 +57,10 @@ Utilities
             #   File ".../base/relengapi/util/tz.py", line 17, in dt_as_timezone
             #     raise ValueError("Must pass a timezone aware datetime object")
             # ValueError: Must pass a timezone aware datetime object
+
+Request ID
+----------
+
+Each request is assigned a unique ID, available in ``g.request_id``.
+This ID is included in structured logging output.
+It may also be helpful to supply this ID to the user when an error occurs, or anywhere it may be useful for debugging.

--- a/relengapi/docs/usage/requests-responses.rst
+++ b/relengapi/docs/usage/requests-responses.rst
@@ -55,7 +55,8 @@ Other top-level response keys may be added during development of the API.
           },
           # ..
         }
-      }
+      },
+      "request_id": "00c3a6aa-a22d-4712-834a-3f9ba328415e"
     }
 
 An error (4xx or 5xx) response will contain an ``error`` object with keys ``code``, ``description``, and ``name`` describing the error:
@@ -77,9 +78,10 @@ An error (4xx or 5xx) response will contain an ``error`` object with keys ``code
         "code": 404,
         "description": "The requested URL was not found on the server.  If you entered the URL manually please check your spelling and try again.",
        "name": "Not Found"
-      }
+      },
+      "request_id": "00c3a6aa-a22d-4712-834a-3f9ba328415e"
     }
 
 For internal server errors, if debug mode is enabled, then the ``error`` object will also contain a ``traceback`` giving the failing Python traceback.
 
-
+In either case, the supplied ``request_id`` can be correlated with server-side logs to aid in debugging.

--- a/relengapi/lib/api.py
+++ b/relengapi/lib/api.py
@@ -14,6 +14,7 @@ import wsme.types
 
 from flask import Response
 from flask import current_app
+from flask import g
 from flask import json
 from flask import jsonify
 from flask import render_template
@@ -29,7 +30,9 @@ class JsonHandler(object):
     media_type = 'application/json'
 
     def render_response(self, result, code, headers):
-        resp = jsonify(result=result)
+        resp = jsonify(
+            result=result,
+            request_id=g.request_id)
         resp.status_code = code
         resp.headers.extend(headers)
         return resp
@@ -40,7 +43,7 @@ class JsonHandler(object):
                 'code': exc_value.code,
                 'name': exc_value.name,
                 'description': exc_value.description,
-            })
+            }, request_id=g.request_id)
             resp.status_code = exc_value.code
         else:
             current_app.log_exception((exc_type, exc_value, exc_tb))
@@ -53,7 +56,8 @@ class JsonHandler(object):
                 error['traceback'] = traceback.format_exc().split('\n')
                 error['name'] = exc_type.__name__
                 error['description'] = str(exc_value)
-            resp = jsonify(error=error)
+            resp = jsonify(error=error,
+                           request_id=g.request_id)
             resp.status_code = 500
         return resp
 

--- a/relengapi/lib/auth/auth_types/constant.py
+++ b/relengapi/lib/auth/auth_types/constant.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import logging
+import structlog
 
 from flask import redirect
 from flask import request
@@ -12,7 +12,7 @@ from flask.ext.login import logout_user
 from relengapi.lib import auth
 from relengapi.lib import safety
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 
 def init_app(app):

--- a/relengapi/lib/auth/auth_types/external.py
+++ b/relengapi/lib/auth/auth_types/external.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import logging
+import structlog
 
 from flask import abort
 from flask import redirect
@@ -13,7 +13,7 @@ from flask.ext.login import logout_user
 from relengapi.lib import auth
 from relengapi.lib import safety
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 
 def init_app(app):

--- a/relengapi/lib/auth/perms_types/ldap_groups.py
+++ b/relengapi/lib/auth/perms_types/ldap_groups.py
@@ -4,7 +4,7 @@
 
 import itertools
 import ldap
-import logging
+import structlog
 
 from relengapi import p
 from relengapi.lib.auth import base
@@ -33,7 +33,7 @@ class LdapGroupsAuthz(base.BaseAuthz):
         self.group_base = permissions_cfg['group_base']
         self.debug = permissions_cfg.get('debug')
 
-        self.logger = logging.getLogger(__name__)
+        self.logger = structlog.get_logger()
 
         permissions_stale.connect_via(app)(self.on_permissions_stale)
 

--- a/relengapi/lib/aws.py
+++ b/relengapi/lib/aws.py
@@ -8,13 +8,14 @@ import boto
 import importlib
 import json
 import logging
+import structlog
 import threading
 import time
 import wsme.rest.json
 
 from boto.sqs import message as sqs_message
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 
 class _StopListening(Exception):

--- a/relengapi/lib/db.py
+++ b/relengapi/lib/db.py
@@ -8,6 +8,7 @@ import logging
 import os
 import pytz
 import sqlalchemy as sa
+import structlog
 import threading
 
 from flask import current_app
@@ -22,7 +23,7 @@ from sqlalchemy.orm import scoping
 from sqlalchemy.pool import Pool
 
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 
 class _QueryProperty(object):

--- a/relengapi/lib/logging.py
+++ b/relengapi/lib/logging.py
@@ -1,0 +1,78 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import
+
+import logging
+import structlog
+import sys
+
+
+stdout_log = None
+
+
+def setupConsoleLogging(quiet):
+    global stdout_log
+    root = logging.getLogger('')
+    if quiet:
+        root.setLevel(logging.WARNING)
+    else:
+        root.setLevel(logging.NOTSET)
+    formatter = logging.Formatter('%(asctime)s %(message)s')
+
+    stdout_log = logging.StreamHandler(sys.stdout)
+    stdout_log.setLevel(logging.DEBUG)
+    stdout_log.setFormatter(formatter)
+    root.addHandler(stdout_log)
+
+
+class UnstructuredRenderer(structlog.processors.KeyValueRenderer):
+
+    def __call__(self, logger, method_name, event_dict):
+        event = event_dict.pop('event')
+        if event_dict:
+            # if there are other keys, use the parent class to render them
+            # and append to the event
+            rendered = super(UnstructuredRenderer, self).__call__(
+                logger, method_name, event_dict)
+            return "%s (%s)" % (event, rendered)
+        else:
+            return event
+
+
+def add_relengapi(logger, method_name, event_dict):
+    event_dict['relengapi'] = True
+    return event_dict
+
+
+def configure_logging(app):
+    if app.config.get('JSON_STRUCTURED_LOGGING'):
+        processors = [
+            structlog.stdlib.filter_by_level,
+            add_relengapi,
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.TimeStamper(fmt='iso'),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.JSONRenderer()
+        ]
+    else:
+        processors = [
+            structlog.stdlib.filter_by_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            UnstructuredRenderer()
+        ]
+
+    if app.config.get('JSON_STRUCTURED_LOGGING') and stdout_log:
+        stdout_log.setFormatter(logging.Formatter('%(message)s'))
+
+    structlog.configure(
+        context_class=dict,
+        processors=processors,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )

--- a/relengapi/lib/memcached.py
+++ b/relengapi/lib/memcached.py
@@ -6,14 +6,14 @@ from __future__ import absolute_import
 
 import contextlib
 import elasticache_auto_discovery
-import logging
 import memcache
 import socket
+import structlog
 import threading
 import time
 import urlparse
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 
 class BaseCacheFinder(object):

--- a/relengapi/lib/testing/context.py
+++ b/relengapi/lib/testing/context.py
@@ -3,14 +3,14 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import inspect
-import logging
 import relengapi.app
+import structlog
 import wrapt
 
 from flask import json
 from relengapi.lib import auth
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger()
 
 
 class TestContext(object):

--- a/relengapi/tests/test_lib_logging.py
+++ b/relengapi/tests/test_lib_logging.py
@@ -1,0 +1,70 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import json
+import logging
+import structlog
+
+from nose.tools import eq_
+from nose.tools import with_setup
+from relengapi.lib import logging as relengapi_logging
+from relengapi.lib.testing.context import TestContext
+
+
+test_context = TestContext()
+
+
+def reset_stdout_log():
+    relengapi_logging.stdout_log = None
+
+
+def remove_stdout_log():
+    logging.getLogger("").removeHandler(relengapi_logging.stdout_log)
+    relengapi_logging.stdout_log = None
+
+
+@with_setup(reset_stdout_log, remove_stdout_log)
+@test_context
+def test_setupConsoleLogging_quiet(app):
+    relengapi_logging.setupConsoleLogging(True)
+    root = logging.getLogger("")
+    stdout_log = relengapi_logging.stdout_log
+    assert stdout_log in root.handlers
+    eq_(root.level, logging.WARNING)
+
+
+@with_setup(reset_stdout_log, remove_stdout_log)
+@test_context
+def test_setupConsoleLogging_loud(app):
+    relengapi_logging.setupConsoleLogging(False)
+    root = logging.getLogger("")
+    stdout_log = relengapi_logging.stdout_log
+    assert stdout_log in root.handlers
+    eq_(root.level, logging.NOTSET)
+
+
+@test_context.specialize(config={'JSON_STRUCTURED_LOGGING': True})
+def test_configure_logging(app):
+    hdlr = logging.handlers.BufferingHandler(100)
+    logging.getLogger(__name__).addHandler(hdlr)
+    try:
+        logger = structlog.get_logger(__name__)
+        logger.info("test message")
+
+        # find that event in the handler..
+        for rec in hdlr.buffer:
+            try:
+                data = json.loads(rec.msg)
+            except Exception:
+                pass
+            if data["event"] == "test message":
+                break
+        else:
+            assert 0, "login exception not logged"
+
+        # check a few other fields
+        eq_(data['relengapi'], True)
+        eq_(data['level'], 'info')
+    finally:
+        logging.getLogger(__name__).removeHandler(hdlr)

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "redo",
         # Temporary freeze until https://github.com/bhearsum/bzrest/pull/3 is fixed
         "bzrest==0.9",
+        "structlog",
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
Structured logging seems the way of the future, and `structlog` provides a nice, simple way to use it with Python's `logging`.

This could be useful for general logging in relengapi, but would be *particularly* useful for logging from celery tasks -- the structure can contain the task id, and processors can then correlate that to a badpenny task or whatever other identifier is required (so a fix for #129)