### PR TITLE
Bug 1173648: fix display, cleanup of badpenny tasks

### DIFF
--- a/relengapi/blueprints/badpenny/static/badpenny.js
+++ b/relengapi/blueprints/badpenny/static/badpenny.js
@@ -198,7 +198,7 @@ angular.module('badpenny').directive('bpJob', function(taskService) {
                     // Humanize just says "a few seconds", which isn't good enough.
                     return "in " + (ms / 1000.0).toFixed(2) + ' seconds';
                 } else {
-                    return "in " + moment.duration(diff).humanize();
+                    return "in " + dur.humanize();
                 }
             };
 

--- a/relengapi/blueprints/badpenny/test_badpenny.py
+++ b/relengapi/blueprints/badpenny/test_badpenny.py
@@ -557,16 +557,17 @@ def test_cleanup(app):
             if log:
                 session.add(tables.BadpennyJobLog(id=id, content=log))
 
-        newjob(1, dt(2014, 9, 20))
-        newjob(2, dt(2014, 9, 15), log="Hello, world\n")
-        newjob(3, dt(2014, 9, 10))
-        newjob(4, dt(2014, 9, 5), log="Hello, world\n")
+        newjob(1, dt(2014, 9, 4))
+        newjob(2, dt(2014, 9, 20))
+        newjob(3, dt(2014, 9, 15), log="Hello, world\n")
+        newjob(4, dt(2014, 9, 10))
+        newjob(5, dt(2014, 9, 5), log="Hello, world\n")
         session.commit()
         with mock.patch('relengapi.blueprints.badpenny.cleanup.time.now') as now:
             now.return_value = dt(2014, 9, 16)
             cleanup.cleanup_old_jobs(job_status)
 
         eq_(sorted([j.id for j in tables.BadpennyJob.query.all()]),
-            sorted([1, 2, 3]))  # 4 is gone
+            sorted([2, 3, 4]))  # 1, 5 are gone
         eq_(sorted([j.id for j in tables.BadpennyJobLog.query.all()]),
-            sorted([2]))  # log for 4 is gone
+            sorted([3]))  # log for 5 is gone


### PR DESCRIPTION
The existing code assumed that tasks were returned in the order they were created, and the tests did nothing to dissuade them (one of the downsides of testing with SQLite).  I bulked up the test a little bit, and refactored the filtering to go job-by-job rather than loading everything into a list, since 7 days of once-a-minute jobs could start to be a lot of RAM.