### PR TITLE
Verify visibilities are set for uploads

### DIFF
--- a/relengapi/blueprints/tooltool/__init__.py
+++ b/relengapi/blueprints/tooltool/__init__.py
@@ -134,10 +134,11 @@ def upload_batch(region=None, body=None):
     except AttributeError:
         raise BadRequest("Could not determine authenticated username")
 
-    # validate permission first
+    # verify permissions based on visibilities
     visibilities = set(f.visibility for f in body.files.itervalues())
     for v in visibilities:
-        if not p.get('tooltool.upload.{}'.format(v)).can():
+        prm = p.get('tooltool.upload.{}'.format(v))
+        if not prm or not prm.can():
             raise Forbidden("no permission to upload {} files".format(v))
 
     session = g.db.session('relengapi')

--- a/relengapi/blueprints/tooltool/test_tooltool.py
+++ b/relengapi/blueprints/tooltool/test_tooltool.py
@@ -354,6 +354,19 @@ def test_upload_batch_mixed_visibility_no_permissions(app, client):
 
 @moto.mock_s3
 @test_context
+def test_upload_batch_no_visibility(app, client):
+    """If no visibility is supplied for a file in a batch, the request is
+    invalid (400)"""
+    # note that it's WSME that enforces this validity
+    batch = mkbatch()
+    del batch['files']['one']['visibility']
+    resp = upload_batch(client, batch)
+    eq_(resp.status_code, 400, resp.data)
+    assert_no_upload_rows(app)
+
+
+@moto.mock_s3
+@test_context
 def test_upload_batch_success_fresh(client, app):
     """A POST to /upload with a good batch succeeds, returns signed URLs expiring
     in one hour, and inserts the new batch into the DB with links to files, but


### PR DESCRIPTION
This avoids some ISEs on manifests that lack visibilities