### PR TITLE
[cosmetic] Disable download link in tooltool if there are no active file instances

### DIFF
--- a/relengapi/blueprints/tooltool/static/tt-result-file.html
+++ b/relengapi/blueprints/tooltool/static/tt-result-file.html
@@ -2,7 +2,7 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
      License, v. 2.0. If a copy of the MPL was not distributed with this
      file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-    <div class="tt-result-controls">
+    <div ng-if="res.has_instances" class="tt-result-controls">
         <a href="/tooltool/{{res.algorithm}}/{{res.digest}}"><span class="glyphicon glyphicon-download download-link" aria-hidden="true"></span>
         <span class="sr-only">Download</span></a>
     </div>

--- a/relengapi/blueprints/tooltool/tables.py
+++ b/relengapi/blueprints/tooltool/tables.py
@@ -35,7 +35,8 @@ class File(db.declarative_base('relengapi')):
             size=self.size,
             digest=self.sha512,
             algorithm='sha512',
-            visibility=self.visibility)
+            visibility=self.visibility,
+            has_instances=any(self.instances))
         if include_instances:
             rv.instances = [i.region for i in self.instances]
         return rv

--- a/relengapi/blueprints/tooltool/test_tooltool.py
+++ b/relengapi/blueprints/tooltool/test_tooltool.py
@@ -213,6 +213,7 @@ def assert_file_response(resp, content, visibility='public', instances=['us-east
         "size": len(content),
         "visibility": visibility,
         'instances': instances,
+        "has_instances": any(instances),
     }
     eq_(json.loads(resp.data)['result'], exp, resp.data)
 
@@ -639,14 +640,16 @@ def test_search_batches(app, client):
             "algorithm": "sha512",
             "digest": ONE_DIGEST,
             "size": len(ONE),
-            "visibility": "public"
+            "visibility": "public",
+            "has_instances": True,
         }
         f2 = add_file_to_db(app, TWO)
         f2j = {
             "algorithm": "sha512",
             "digest": TWO_DIGEST,
             "size": len(TWO),
-            "visibility": "public"
+            "visibility": "public",
+            "has_instances": True,
         }
         add_batch_to_db(
             app, 'me@me.com', 'first batch', {'one': f1})
@@ -718,13 +721,15 @@ def test_get_batch_found(client):
                 "algorithm": "sha512",
                 "digest": ONE_DIGEST,
                 "size": len(ONE),
-                "visibility": "public"
+                "visibility": "public",
+                "has_instances": False,
             },
             "two": {
                 "algorithm": "sha512",
                 "digest": TWO_DIGEST,
                 "size": len(TWO),
-                "visibility": "public"
+                "visibility": "public",
+                "has_instances": False,
             }
         },
         "id": 1,
@@ -740,14 +745,16 @@ def test_get_files(app, client):
         "algorithm": "sha512",
         "digest": ONE_DIGEST,
         "size": len(ONE),
-        "visibility": "public"
+        "visibility": "public",
+        "has_instances": True,
     }
     f2 = add_file_to_db(app, TWO)
     f2j = {
         "algorithm": "sha512",
         "digest": TWO_DIGEST,
         "size": len(TWO),
-        "visibility": "public"
+        "visibility": "public",
+        "has_instances": True,
     }
     add_batch_to_db(
         app, 'me@me.com', 'first batch', {'one': f1})

--- a/relengapi/blueprints/tooltool/types.py
+++ b/relengapi/blueprints/tooltool/types.py
@@ -28,6 +28,9 @@ class File(wsme.types.Base):
         wsme.types.Enum(unicode, 'public', 'internal'),
         mandatory=True)
 
+    #: Boolean to determine whether the file is available to download.
+    has_instances = bool
+
     #: The regions containing an instance of this file.  This field is generally
     #: omitted except where specified
     instances = [unicode]


### PR DESCRIPTION
The tooltool page exposes the download link to files with nonexistent instances. This pr disables the download link link so you aren't redirected to a broken link, which  could be the result of removed instances or incomplete file uploads.
