### PR TITLE
Archiver

### DIFF
--- a/relengapi/blueprints/archiver/tables.py
+++ b/relengapi/blueprints/archiver/tables.py
@@ -1,0 +1,12 @@
+import sqlalchemy as sa
+
+from relengapi.lib import db
+
+class ArchiverTask(db.declarative_base('relengapi')):
+    __tablename__ = 'archiver_tasks'
+    id = sa.Column(sa.Integer, primary_key=True)
+    task_id = sa.Column(sa.String(100), nullable=False, unique=True)
+    created_at = sa.Column(db.UTCDateTime(timezone=True), nullable=False)
+    state = sa.Column(sa.String(50))
+    # for debugging
+    src_url = sa.Column(sa.String(200))

--- a/relengapi/blueprints/archiver/tables.py
+++ b/relengapi/blueprints/archiver/tables.py
@@ -2,6 +2,7 @@ import sqlalchemy as sa
 
 from relengapi.lib import db
 
+
 class ArchiverTask(db.declarative_base('relengapi')):
     __tablename__ = 'archiver_tasks'
     id = sa.Column(sa.Integer, primary_key=True)

--- a/relengapi/blueprints/archiver/test_archiver.py
+++ b/relengapi/blueprints/archiver/test_archiver.py
@@ -2,11 +2,17 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import json
+import datetime
+import pytz
 import mock
 import moto
 
 from nose.tools import eq_
-from relengapi.blueprints.archiver.test_util import EXPECTED_TASK_STATUS_FAILED_RESPONSE
+from relengapi.blueprints.archiver import tables, update_tracker_state, delete_tracker, \
+    TASK_TIME_OUT, cleanup_old_tasks
+from relengapi.lib import time
+from relengapi.blueprints.archiver.test_util import EXPECTED_TASK_STATUS_FAILED_RESPONSE, \
+    EXPECTED_TASK_STATUS_INCOMPLETE_RESPONSE, fake_incomplete_task_status
 from relengapi.blueprints.archiver.test_util import EXPECTED_TASK_STATUS_SUCCESSFUL_RESPONSE
 from relengapi.blueprints.archiver.test_util import create_s3_items
 from relengapi.blueprints.archiver.test_util import fake_200_response
@@ -37,8 +43,14 @@ cfg = {
     'CELERY_ALWAYS_EAGER': True,
 }
 
-test_context = TestContext(config=cfg)
+test_context = TestContext(config=cfg, databases=['relengapi'])
 
+def create_fake_tracker_row(app, id, created_at=None, src_url='https://foo.com', state="PENDING"):
+    if not created_at:
+        created_at = time.now()
+    session = app.db.session('relengapi')
+    session.add(tables.ArchiverTask(task_id=id, created_at=created_at, src_url=src_url, state=state))
+    session.commit()
 
 @moto.mock_s3
 @test_context
@@ -78,7 +90,7 @@ def test_redirect_response_when_found_s3_key(app, client):
 def test_task_status_when_failed(app, client):
     expected_response = EXPECTED_TASK_STATUS_FAILED_RESPONSE
     with mock.patch("relengapi.blueprints.archiver.create_and_upload_archive") as caua:
-        caua.AsyncResult.side_effect = fake_failed_task_status
+        caua.AsyncResult.return_value = fake_failed_task_status()
         response = client.get('/archiver/status/{task_id}'.format(task_id=123))
     eq_(cmp(json.loads(response.data)['result'], expected_response), 0,
         "a failed task status check does not equal expected status.")
@@ -89,7 +101,113 @@ def test_task_status_when_failed(app, client):
 def test_task_status_when_success(app, client):
     expected_response = EXPECTED_TASK_STATUS_SUCCESSFUL_RESPONSE
     with mock.patch("relengapi.blueprints.archiver.create_and_upload_archive") as caua:
-        caua.AsyncResult.return_value = fake_successful_task_status(expected_response)
+        caua.AsyncResult.return_value = fake_successful_task_status()
         response = client.get('/archiver/status/{task_id}'.format(task_id=123))
     eq_(cmp(json.loads(response.data)['result'], expected_response), 0,
         "A successful task status check does not equal expected status.")
+
+
+@moto.mock_s3
+@test_context
+def test_tracker_delete(app, client):
+    with app.app_context():
+        create_fake_tracker_row(app, 'foo')
+        tracker = tables.ArchiverTask.query.filter(tables.ArchiverTask.task_id == 'foo').first()
+        eq_(tracker.task_id, "foo", "original tracker did not persist")
+        delete_tracker(tracker)
+        tracker = tables.ArchiverTask.query.filter(tables.ArchiverTask.task_id == 'foo').first()
+        eq_(tracker, None, "tracker was not deleted")
+
+
+@moto.mock_s3
+@test_context
+def test_tracker_update(app, client):
+    with app.app_context():
+        create_fake_tracker_row(app, 'foo')
+        tracker = tables.ArchiverTask.query.filter(tables.ArchiverTask.task_id == 'foo').first()
+        eq_(tracker.state, "PENDING", "original tracker state did not persist")
+        update_tracker_state(tracker, "SUCCESS")
+        eq_(tracker.state, "SUCCESS", "original tracker state was not updated.")
+
+
+
+@moto.mock_s3
+@test_context
+def test_tracker_added_when_celery_task_is_created(app, client):
+    setup_buckets(app, cfg)
+    with mock.patch("relengapi.blueprints.archiver.tasks.requests.get") as get, \
+            mock.patch("relengapi.blueprints.archiver.tasks.requests.head") as head:
+        # don't actually hit hg.m.o, we just care about starting a subprocess and
+        # returning a 202 accepted
+        get.return_value = fake_200_response()
+        head.return_value = fake_200_response()
+        client.get('/archiver/hgmo/mozilla-central/9213957d166d?'
+                   'subdir=testing/mozharness&preferred_region=us-west-2')
+        with app.app_context():
+            expected_tracker_id = "mozilla-central-9213957d166d.tar.gz_testing_mozharness"
+            tracker = tables.ArchiverTask.query.filter(
+                tables.ArchiverTask.task_id == expected_tracker_id
+            ).first()
+            eq_(tracker.task_id, expected_tracker_id, "tracker was not created for celery task")
+
+
+
+
+@moto.mock_s3
+@test_context
+def test_tracker_is_updated_when_task_state_changes_but_is_not_complete(app, client):
+    with app.app_context():
+        task_id = 'foo'
+        session = app.db.session('relengapi')
+        session.add(tables.ArchiverTask(task_id=task_id, created_at=time.now(),
+                                        src_url='https://foo.com', state="PENDING"))
+        session.commit()
+        with mock.patch("relengapi.blueprints.archiver.create_and_upload_archive") as caua:
+            caua.AsyncResult.return_value = fake_incomplete_task_status()
+            client.get('/archiver/status/{task_id}'.format(task_id=task_id))
+        tracker = tables.ArchiverTask.query.filter(tables.ArchiverTask.task_id == task_id).first()
+        eq_(tracker.state, "STARTED", "tracker not updated even though celery task state changed.")
+
+
+@moto.mock_s3
+@test_context
+def test_tracker_is_deleted_when_task_status_shows_task_complete(app, client):
+    with app.app_context():
+        task_id = 'foo'
+        session = app.db.session('relengapi')
+        session.add(tables.ArchiverTask(task_id=task_id, created_at=time.now(),
+                                        src_url='https://foo.com', state="PENDING"))
+        session.commit()
+        with mock.patch("relengapi.blueprints.archiver.create_and_upload_archive") as caua:
+            caua.AsyncResult.return_value = fake_successful_task_status()
+            client.get('/archiver/status/{task_id}'.format(task_id=task_id))
+        tracker = tables.ArchiverTask.query.filter(tables.ArchiverTask.task_id == task_id).first()
+        eq_(tracker, None, "tracker was not deleted even though celery task completed.")
+
+
+@moto.mock_s3
+@test_context
+def test_task_tracker_badpenny_cleanup(app, client):
+    now = datetime.datetime(2015, 7, 14, 23, 19, 42, tzinfo=pytz.UTC)  # freeze time
+    with app.app_context():
+        session = app.db.session('relengapi')
+        with mock.patch('relengapi.blueprints.archiver.now') as time_traveller:
+            time_traveller.return_value = now
+
+            # create some tasks
+            expired_time1 = now - datetime.timedelta(seconds=TASK_TIME_OUT + 10)
+            expired_time2 = now - datetime.timedelta(seconds=TASK_TIME_OUT + 20)
+            valid_time1 = now - datetime.timedelta(seconds=TASK_TIME_OUT - 10)
+            create_fake_tracker_row(app, 'expired_task1', created_at=expired_time1)
+            create_fake_tracker_row(app, 'expired_task2', created_at=expired_time2)
+            create_fake_tracker_row(app, 'valid_task1', created_at=valid_time1)
+            # ensure they were created
+            eq_(session.query(tables.ArchiverTask).count(), 3,
+                "couldn't create fake task trackers for testing.")
+            # force run badpenny clean up job
+            cleanup_old_tasks()
+            eq_(session.query(tables.ArchiverTask).count(), 1,
+                "expected only one tracker task to persist after cleaning up old tasks")
+            tracker = session.query(tables.ArchiverTask).first()
+            eq_(tracker.task_id, 'valid_task1',
+                "remaining tracker did not match expected.")

--- a/relengapi/blueprints/archiver/test_archiver.py
+++ b/relengapi/blueprints/archiver/test_archiver.py
@@ -1,24 +1,27 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-import json
 import datetime
-import pytz
+import json
 import mock
 import moto
+import pytz
 
 from nose.tools import eq_
-from relengapi.blueprints.archiver import tables, update_tracker_state, delete_tracker, \
-    TASK_TIME_OUT, cleanup_old_tasks
-from relengapi.lib import time
-from relengapi.blueprints.archiver.test_util import EXPECTED_TASK_STATUS_FAILED_RESPONSE, \
-    EXPECTED_TASK_STATUS_INCOMPLETE_RESPONSE, fake_incomplete_task_status
+from relengapi.blueprints.archiver import TASK_TIME_OUT
+from relengapi.blueprints.archiver import cleanup_old_tasks
+from relengapi.blueprints.archiver import delete_tracker
+from relengapi.blueprints.archiver import tables
+from relengapi.blueprints.archiver import update_tracker_state
+from relengapi.blueprints.archiver.test_util import EXPECTED_TASK_STATUS_FAILED_RESPONSE
 from relengapi.blueprints.archiver.test_util import EXPECTED_TASK_STATUS_SUCCESSFUL_RESPONSE
 from relengapi.blueprints.archiver.test_util import create_s3_items
 from relengapi.blueprints.archiver.test_util import fake_200_response
 from relengapi.blueprints.archiver.test_util import fake_failed_task_status
+from relengapi.blueprints.archiver.test_util import fake_incomplete_task_status
 from relengapi.blueprints.archiver.test_util import fake_successful_task_status
 from relengapi.blueprints.archiver.test_util import setup_buckets
+from relengapi.lib import time
 
 from relengapi.lib.testing.context import TestContext
 
@@ -45,12 +48,16 @@ cfg = {
 
 test_context = TestContext(config=cfg, databases=['relengapi'])
 
+
 def create_fake_tracker_row(app, id, created_at=None, src_url='https://foo.com', state="PENDING"):
     if not created_at:
         created_at = time.now()
     session = app.db.session('relengapi')
-    session.add(tables.ArchiverTask(task_id=id, created_at=created_at, src_url=src_url, state=state))
+    session.add(
+        tables.ArchiverTask(task_id=id, created_at=created_at, src_url=src_url, state=state)
+    )
     session.commit()
+
 
 @moto.mock_s3
 @test_context
@@ -130,7 +137,6 @@ def test_tracker_update(app, client):
         eq_(tracker.state, "SUCCESS", "original tracker state was not updated.")
 
 
-
 @moto.mock_s3
 @test_context
 def test_tracker_added_when_celery_task_is_created(app, client):
@@ -149,8 +155,6 @@ def test_tracker_added_when_celery_task_is_created(app, client):
                 tables.ArchiverTask.task_id == expected_tracker_id
             ).first()
             eq_(tracker.task_id, expected_tracker_id, "tracker was not created for celery task")
-
-
 
 
 @moto.mock_s3

--- a/relengapi/blueprints/archiver/test_util.py
+++ b/relengapi/blueprints/archiver/test_util.py
@@ -86,4 +86,3 @@ def fake_incomplete_task_status():
     task.state = EXPECTED_TASK_STATUS_INCOMPLETE_RESPONSE['state']
     task.info = EXPECTED_TASK_STATUS_INCOMPLETE_RESPONSE['status']
     return task
-

--- a/relengapi/blueprints/archiver/test_util.py
+++ b/relengapi/blueprints/archiver/test_util.py
@@ -11,6 +11,13 @@ EXPECTED_TASK_STATUS_FAILED_RESPONSE = {
               ", u'exc_type': u'AttributeError'}"
 }
 
+EXPECTED_TASK_STATUS_INCOMPLETE_RESPONSE = {
+    "s3_urls": {},
+    "src_url": "",
+    "state": "STARTED",
+    "status": "no task status at this point",
+}
+
 EXPECTED_TASK_STATUS_SUCCESSFUL_RESPONSE = {
     "s3_urls": {
         "us-east-1": "https://archiver-us-east-1.s3.amazonaws.com/mozilla-central-9213957d1.tar.gz",
@@ -56,14 +63,14 @@ def fake_404_response():
     return response
 
 
-def fake_failed_task_status(task_id):
+def fake_failed_task_status():
     task = mock.Mock()
     task.state = EXPECTED_TASK_STATUS_FAILED_RESPONSE['state']
     task.info = EXPECTED_TASK_STATUS_FAILED_RESPONSE['status']
     return task
 
 
-def fake_successful_task_status(task_id):
+def fake_successful_task_status():
     task = mock.Mock()
     task.state = EXPECTED_TASK_STATUS_SUCCESSFUL_RESPONSE['state']
     task.info = {
@@ -72,3 +79,11 @@ def fake_successful_task_status(task_id):
         'status': EXPECTED_TASK_STATUS_SUCCESSFUL_RESPONSE['status'],
     }
     return task
+
+
+def fake_incomplete_task_status():
+    task = mock.Mock()
+    task.state = EXPECTED_TASK_STATUS_INCOMPLETE_RESPONSE['state']
+    task.info = EXPECTED_TASK_STATUS_INCOMPLETE_RESPONSE['status']
+    return task
+

--- a/relengapi/docs/deployment/archiver.rst
+++ b/relengapi/docs/deployment/archiver.rst
@@ -8,9 +8,16 @@ the endpoint.
 For AWS credentials, each bucket should be limited to the AWS IAM role corresponding to the AWS credentials. Buckets in
 the configuration are required to be pre-existing.
 
+Archiver also uses a db for tracking celery tasks in order not to create duplicates.
+Like other parts of relengapi that have a db component, you must supply a sqlalchemy uri.
+
 Finally, Archiver uses Celery. You will need to provide a broker and back-end.
 
 Example config::
+
+    SQLALCHEMY_DATABASE_URIS = {
+       'relengapi': 'sqlite:////tmp/relengapi.db',
+    }
 
     # using rabbitmq locally in a staging setup
     CELERY_BROKER_URL='amqp://guest@localhost//'

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 
 setup(
     name='relengapi',
-    version='3.1.0',
+    version='3.1.1',
     description='The code behind https://api.pub.build.mozilla.org',
     author='Dustin J. Mitchell',
     author_email='dustin@mozilla.com',


### PR DESCRIPTION
This  combats against creating multiple celery tasks for the same job and manages clean up. It does this by:

* setting a time limit of how long a task can run for (protecting from getting hung tasks)
* setting an expiry of how long a task can be un-actioned in the message queue
* tracking the state of celery tasks with a db backend.
 * Prior to this I only tracked if the state given by celery was 'STARTED'. But celery tasks could also be PENDING or RETRY. You can't trust PENDING as that's the default state for tasks that were never even created.
* explicitly capping the revision at 12 chars.
    * If a buildbot job or user hits the archiver api with both the short hash and the long hash, archiver used to think this was two separate archives. This could be an issue if a bunch of buildbot jobs have the short hash stored in buildbot properties.
* some house keeping with the trackers in the db. If the task goes past it's time limit or is in a finished state and the tracker still exists in the db, a badpenny job will clean it up.
* add more logging to help track health of archiver

Though *much* more work than simply:  `if create_and_upload_archive.AsyncResult(task_id).state != 'STARTED'`, managing the tasks through a tracker should provide us with much more control.
