### PR TITLE
bug 1182532 - log task_id not the sql gen id when deleting archiver tracker tasks

### DIFF
--- a/relengapi/blueprints/archiver/__init__.py
+++ b/relengapi/blueprints/archiver/__init__.py
@@ -32,7 +32,7 @@ FINISHED_STATES = ['SUCCESS', 'FAILURE', 'REVOKED']
 
 def delete_tracker(tracker):
     session = current_app.db.session('relengapi')
-    log.info("deleting tracker with id: {}".format(tracker.id))
+    log.info("deleting tracker with id: {}".format(tracker.task_id))
     session.delete(tracker)
     session.commit()
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 
 setup(
     name='relengapi',
-    version='3.1.1',
+    version='3.1.2',
     description='The code behind https://api.pub.build.mozilla.org',
     author='Dustin J. Mitchell',
     author_email='dustin@mozilla.com',


### PR DESCRIPTION
quick typo fix in logging. forgive me if I should have asked for a review on this before landing