### PR TITLE
add api.loads and api.dumps

### DIFF
--- a/relengapi/docs/development/api_methods.rst
+++ b/relengapi/docs/development/api_methods.rst
@@ -34,10 +34,26 @@ See the WSME_ documentation for more detail.
 
 As a utility, an arbitrary JSON Object can be described with this class:
 
-.. attribute:: relengapi.lib.api.jsonObject
+.. py:attribute:: relengapi.lib.api.jsonObject
 
     A WSME custom type describing an arbitrary JSON object.
     This validates that the value is an object (equivalent to a ``dict`` in Python) and that it can be JSON-encoded.
+
+If you find the need to convert such objects to or from JSON strings, use these functions:
+
+.. py:function:: relengapi.lib.api.dumps(datatype, obj)
+
+    Dump the given object as a JSON string, assuming it is of the given WSME datatype.
+    For example::
+
+        print(api.dumps(JsonThing, my_thing))
+
+.. py:function:: relengapi.lib.api.loads(datatype, obj)
+
+    Load the given object from a JSON string, assuming it is of the given WSME datatype.
+    For example::
+
+        api.loads(JsonThing, data)
 
 Decorator
 ---------

--- a/relengapi/docs/development/api_methods.rst
+++ b/relengapi/docs/development/api_methods.rst
@@ -32,6 +32,9 @@ Compound types are defined by subclassing ``wsme.types.Base``::
 
 See the WSME_ documentation for more detail.
 
+Manually Converting to/from JSON
+................................
+
 As a utility, an arbitrary JSON Object can be described with this class:
 
 .. py:attribute:: relengapi.lib.api.jsonObject
@@ -54,6 +57,24 @@ If you find the need to convert such objects to or from JSON strings, use these 
     For example::
 
         api.loads(JsonThing, data)
+
+As an example, assume the type::
+
+    class TestType(wsme.types.Base):
+        name = unicode
+        value = int
+
+Then:
+
+.. code-block:: none
+
+    >>> thing = TestType(name='n', value=3)
+    >>> api.dumps(TestType, thing)
+    '{"name": "n", "value": 3}'
+    >>> api.loads(TestType, '{"name": "n", "value": 3}')
+    <TestType object at 0x7fdb7a20f790>  # not a dictionary
+    >>> _.name, _.value
+    (u'n', 3)
 
 Decorator
 ---------

--- a/relengapi/lib/api.py
+++ b/relengapi/lib/api.py
@@ -168,6 +168,14 @@ class JsonObject(wsme.types.UserType):
 jsonObject = JsonObject()
 
 
+def dumps(datatype, obj):
+    return json.dumps(wsme.rest.json.tojson(datatype, obj))
+
+
+def loads(datatype, data):
+    return wsme.rest.json.fromjson(datatype, json.loads(data))
+
+
 def init_app(app):
     # install a universal error handler that will render errors based on the
     # Accept header in the request

--- a/relengapi/tests/test_lib_api.py
+++ b/relengapi/tests/test_lib_api.py
@@ -270,3 +270,13 @@ def test_date_formatting():
     j = {'when': '2015-02-28T01:02:03+00:00'}
     eq_(tojson(TypeWithDate, d), j)
     eq_(fromjson(TypeWithDate, j).when, d.when)
+
+
+def test_dumps():
+    thing = TestType(name="n", value=3)
+    eq_(json.loads(api.dumps(TestType, thing)), dict(name=u"n", value=3))
+
+
+def test_loads():
+    thing = api.loads(TestType, '{"name": "n", "value": 3}')
+    eq_((thing.name, thing.value), (u'n', 3))


### PR DESCRIPTION
Regular old `json.dumps` will barf on a WSME type; and `json.loads` will successfully load such a thing, but represent it as a dictionary rather than a WSME object.  These little gems take care of both problems.