### PR TITLE
Port Treestatus

### DIFF
--- a/relengapi/app.py
+++ b/relengapi/app.py
@@ -86,6 +86,7 @@ blueprints = [_load_bp(n) for n in [
     'tokenauth',
     'tooltool',
     'archiver',
+    'treestatus',
 ]]
 
 

--- a/relengapi/blueprints/treestatus/__init__.py
+++ b/relengapi/blueprints/treestatus/__init__.py
@@ -36,7 +36,6 @@ TREE_SUMMARY_LOG_LIMIT = 5
 # TODO: replicate cache control headers
 # TODO: use elasticache
 # TODO: test deleting a tree with logs or history
-# TODO: add "refresh", run it periodically
 
 def update_tree_status(session, tree, status=None, reason=None,
                        tags=[], message_of_the_day=None):

--- a/relengapi/blueprints/treestatus/__init__.py
+++ b/relengapi/blueprints/treestatus/__init__.py
@@ -1,0 +1,306 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import json
+import logging
+import sqlalchemy as sa
+
+from flask import Blueprint
+from flask import current_app
+from flask import url_for
+from flask.ext.login import current_user
+from relengapi import apimethod
+from relengapi.lib import angular
+from relengapi.lib import api
+from relengapi.lib import time as relengapi_time
+from werkzeug.exceptions import BadRequest
+from werkzeug.exceptions import NotFound
+
+from relengapi import p
+from relengapi.blueprints.treestatus import model
+from relengapi.blueprints.treestatus import types
+
+bp = Blueprint('treestatus', __name__,
+               static_folder='static',
+               template_folder='templates')
+
+p.treestatus.sheriff.doc('Modify tree status (open and close trees)')
+p.treestatus.admin.doc('Administrate treestatus (add, delete, modify trees)')
+
+log = logging.getLogger(__name__)
+TREE_SUMMARY_LOG_LIMIT = 5
+
+
+# TODO: replicate cache control headers
+# TODO: use elasticache
+# TODO: rename columns, tables
+# TODO: remove user table, tokens
+# TODO: test deleting a tree with logs or history
+# TODO: add "refresh", run it periodically
+# TODO: allow editing reason without affecting stack
+
+def update_tree_status(session, tree, status=None, reason=None, tags=[]):
+    """Update the given tree's status; note that this does not commit
+    the session.  Supply a tree object or name."""
+    if not hasattr(tree, 'tree'):
+        tree = session.query(model.DbTree).get(tree)
+        if not tree:
+            raise NotFound
+
+    if status is not None:
+        tree.status = status
+    if reason is not None:
+        tree.reason = reason
+
+    # log it
+    if status or reason:
+        l = model.DbLog(
+            tree=tree.tree,
+            when=relengapi_time.now(),
+            who=str(current_user),
+            action=status,  # action, status same thing
+            reason=reason,
+            tags=tags)
+        session.add(l)
+
+
+@bp.route('/')
+def index():
+    return angular.template('index.html',
+                            url_for('.static', filename='treestatus.js'),
+                            url_for('.static', filename='treestatus.css'),
+                            stack=api.get_data(get_stack),
+                            trees=api.get_data(get_trees))
+
+
+@bp.route('/details/<path:tree>')
+def show_tree_details(tree):
+    return angular.template('tree.html',
+                            url_for('.static', filename='treestatus.js'),
+                            url_for('.static', filename='treestatus.css'),
+                            tree=api.get_data(get_tree, tree),
+                            logs=api.get_data(get_logs, tree))
+
+
+@bp.route('/trees')
+@apimethod({unicode: types.JsonTree})
+def get_trees():
+    """
+    Get the status of all trees.
+    """
+    trees = {}
+    for t in current_app.db.session('treestatus').query(model.DbTree):
+        trees[t.tree] = t.to_json()
+    return trees
+
+
+@bp.route('/trees/<path:tree>')
+@apimethod(types.JsonTree, unicode)
+def get_tree(tree):
+    """
+    Get the status of a single tree.
+    """
+    t = current_app.db.session('treestatus').query(model.DbTree).get(tree)
+    if not t:
+        raise NotFound("No such tree")
+    return t.to_json()
+
+
+@bp.route('/trees/<path:tree_name>', methods=['PUT'])
+@p.treestatus.admin.require()
+@apimethod(None, unicode, body=types.JsonTree)
+def make_tree(tree_name, body):
+    """Make a new tree."""
+    session = current_app.db.session('treestatus')
+    if body.tree != tree_name:
+        raise BadRequest("Tree names must match")
+    t = model.DbTree(
+        tree=tree_name,
+        status=body.status,
+        reason=body.reason,
+        message_of_the_day=body.message_of_the_day)
+    try:
+        session.add(t)
+        session.commit()
+    except (sa.exc.IntegrityError, sa.exc.ProgrammingError):
+        raise BadRequest("tree already exists")
+    return None, 204
+
+
+# TODO: make a generic set-motd method?  Why check that everything else
+# matches?  Or just allow updates with optional fields?
+@bp.route('/trees/<path:tree_name>', methods=['PATCH'])
+@p.treestatus.sheriff.require()
+@apimethod(unicode, unicode, body=types.JsonTree)
+def modify_tree(tree_name, body):
+    """Modify a tree.  This cannot modify the tree's status, reason, or name."""
+    session = current_app.db.session('treestatus')
+    t = current_app.db.session('treestatus').query(model.DbTree).get(tree_name)
+    if not t:
+        raise NotFound("No such tree")
+    # ensure everything matches
+    if body.tree != tree_name:
+        raise BadRequest("Tree names must match")
+    if body.status != t.status:
+        raise BadRequest("Cannot modify status (use UPDATE instead)")
+    if body.reason != t.reason:
+        raise BadRequest("Cannot modify reason (use UPDATE instead)")
+    t.message_of_the_day = body.message_of_the_day
+    session.commit()
+    return None, 204
+
+
+@bp.route('/trees/<path:tree>', methods=['DELETE'])
+@p.treestatus.admin.require()
+@apimethod(None, unicode)
+def kill_tree(tree):
+    """Delete a tree."""
+    session = current_app.db.session('treestatus')
+    t = session.query(model.DbTree).get(tree)
+    if not t:
+        raise NotFound("No such tree")
+    session.delete(t)
+    session.commit()
+    return None, 204
+
+
+@bp.route('/trees/<path:tree>/logs')
+@apimethod([types.JsonTreeLog], unicode, int)
+def get_logs(tree, all=0):
+    """
+    Get a log of changes for the given tree.  This is limited to the most recent
+    5 entries by default.  Use `?all=1` to get all log entries.
+    """
+    # verify the tree exists first
+    t = current_app.db.session('treestatus').query(model.DbTree).get(tree)
+    if not t:
+        raise NotFound("No such tree")
+
+    logs = []
+    q = current_app.db.session('treestatus').query(
+        model.DbLog).filter_by(tree=tree)
+    q = q.order_by(model.DbLog.when.desc())
+    if not all:
+        q = q.limit(TREE_SUMMARY_LOG_LIMIT)
+
+    logs = [l.to_json() for l in q]
+    return logs
+
+
+@bp.route('/stack', methods=['GET'])
+@apimethod([types.JsonStateChange])
+def get_stack():
+    """
+    Get the "undo stack" of changes to trees, most recent first.
+    """
+    tbl = model.DbStatusStack
+    return [st.to_json() for st in tbl.query.order_by(tbl.when.desc())]
+
+
+@bp.route('/stack/<int:id>', methods=['REVERT'])
+@p.treestatus.sheriff.require()
+@apimethod(None, int)
+def revert_change(id):
+    """
+    Revert the given change from the undo stack.
+
+    This applies the settings that were present before the change to the
+    affected trees, and deletes the change from the stack.
+    """
+    session = current_app.db.session('treestatus')
+    ch = session.query(model.DbStatusStack).get(id)
+    if not ch:
+        raise NotFound
+
+    for t in ch.trees:
+        # TODO: test last_state is correct
+        last_state = json.loads(t.last_state)
+        try:
+            update_tree_status(
+                session, t.tree,
+                status=last_state['status'],
+                reason=last_state['reason'])
+        except NotFound:
+            # if there's no tree to update, don't worry about it
+            pass
+
+    session.delete(ch)
+    session.commit()
+    return None, 204
+
+
+@bp.route('/stack/<int:id>', methods=['DELETE'])
+@p.treestatus.sheriff.require()
+@apimethod(None, int)
+def delete_change(id):
+    """
+    Delete the given change from the undo stack, without applying it.
+    """
+    session = current_app.db.session('treestatus')
+    ch = session.query(model.DbStatusStack).get(id)
+    if not ch:
+        raise NotFound
+
+    session.delete(ch)
+    session.commit()
+
+    return None, 204
+
+
+@bp.route('/trees', methods=['UPDATE'])
+@p.treestatus.sheriff.require()
+@apimethod(None, body=types.JsonTreeUpdate)
+def update_trees(body):
+    """
+    Update trees' status.
+
+    If the update indicates that the previous state should be saved, then a new
+    change will be added to the undo stack containing the previous state.
+    Otherwise, all affected trees will be removed from the undo stack, which
+    may result in changes being removed from the stack when no trees remain.
+
+    The `tags` must not be empty if `status` is `closed`.
+    """
+    session = current_app.db.session('treestatus')
+    trees = [session.query(model.DbTree).get(t) for t in body.trees]
+    if not all(trees):
+        raise NotFound("one or more trees not found")
+
+    if body.status == 'closed' and not body.tags:
+        raise BadRequest("tags are required when closing a tree")
+
+    if body.remember:
+        # add a new stack entry with the existing states
+        st = model.DbStatusStack(
+            who=str(current_user),
+            reason=body.reason,
+            when=relengapi_time.now(),
+            status=body.status)
+        for tree in trees:
+            stt = model.DbStatusStackTree(
+                tree=tree.tree,
+                last_state=json.dumps(
+                    {'status': tree.status, 'reason': tree.reason}))
+            st.trees.append(stt)
+        session.add(st)
+    else:
+        tree_names = set(t.tree for t in trees)
+        # delete any stack records for this tree
+        for st in session.query(model.DbStatusStack):
+            for t in st.trees[:]:
+                if t.tree in tree_names:
+                    session.delete(t)
+                    st.trees.remove(t)
+            if not st.trees:
+                session.delete(st)
+
+    # update the trees as requested
+    for tree in trees:
+        update_tree_status(session, tree,
+                           status=body.status,
+                           reason=body.reason,
+                           tags=body.tags)
+
+    session.commit()
+    return None, 204

--- a/relengapi/blueprints/treestatus/__init__.py
+++ b/relengapi/blueprints/treestatus/__init__.py
@@ -13,6 +13,7 @@ from flask.ext.login import current_user
 from relengapi import apimethod
 from relengapi.lib import angular
 from relengapi.lib import api
+from relengapi.lib import http
 from relengapi.lib import time as relengapi_time
 from werkzeug.exceptions import BadRequest
 from werkzeug.exceptions import NotFound
@@ -31,10 +32,12 @@ p.treestatus.admin.doc('Administrate treestatus (add, delete, modify trees)')
 
 log = logging.getLogger(__name__)
 TREE_SUMMARY_LOG_LIMIT = 5
+public_data = http.response_headers(
+    ('cache-control', 'no-cache'),
+    ('access-control-allow-origin', '*'))
 
-
-# TODO: replicate cache control headers
 # TODO: use elasticache
+
 
 def update_tree_status(session, tree, status=None, reason=None,
                        tags=[], message_of_the_day=None):
@@ -82,6 +85,7 @@ def show_tree_details(tree):
 
 
 @bp.route('/trees')
+@public_data
 @apimethod({unicode: types.JsonTree})
 def get_trees():
     """
@@ -94,6 +98,7 @@ def get_trees():
 
 
 @bp.route('/trees/<path:tree>')
+@public_data
 @apimethod(types.JsonTree, unicode)
 def get_tree(tree):
     """
@@ -144,6 +149,7 @@ def kill_tree(tree):
 
 
 @bp.route('/trees/<path:tree>/logs')
+@public_data
 @apimethod([types.JsonTreeLog], unicode, int)
 def get_logs(tree, all=0):
     """

--- a/relengapi/blueprints/treestatus/__init__.py
+++ b/relengapi/blueprints/treestatus/__init__.py
@@ -84,7 +84,6 @@ def tree_cache_get(tree):
         data = mc.get(tree.encode('utf-8'))
         if not data:
             return
-        print "HIT"
         return api.loads(types.JsonTree, data.decode('utf-8'))
 
 

--- a/relengapi/blueprints/treestatus/__init__.py
+++ b/relengapi/blueprints/treestatus/__init__.py
@@ -35,7 +35,6 @@ TREE_SUMMARY_LOG_LIMIT = 5
 
 # TODO: replicate cache control headers
 # TODO: use elasticache
-# TODO: test deleting a tree with logs or history
 
 def update_tree_status(session, tree, status=None, reason=None,
                        tags=[], message_of_the_day=None):
@@ -137,6 +136,9 @@ def kill_tree(tree):
     if not t:
         raise NotFound("No such tree")
     session.delete(t)
+    # delete from logs and change stack, too
+    model.DbLog.query.filter_by(tree=tree).delete()
+    model.DbStatusChangeTree.query.filter_by(tree=tree).delete()
     session.commit()
     return None, 204
 

--- a/relengapi/blueprints/treestatus/__init__.py
+++ b/relengapi/blueprints/treestatus/__init__.py
@@ -129,7 +129,7 @@ def get_trees():
     Get the status of all trees.
     """
     trees = {}
-    for t in current_app.db.session('treestatus').query(model.DbTree):
+    for t in current_app.db.session('relengapi').query(model.DbTree):
         trees[t.tree] = t.to_json()
     return trees
 
@@ -147,7 +147,7 @@ def get_tree(tree):
     r = tree_cache_get(tree)
     if r:
         return r
-    t = current_app.db.session('treestatus').query(model.DbTree).get(tree)
+    t = current_app.db.session('relengapi').query(model.DbTree).get(tree)
     if not t:
         raise NotFound("No such tree")
     j = t.to_json()
@@ -160,7 +160,7 @@ def get_tree(tree):
 @apimethod(None, unicode, body=types.JsonTree)
 def make_tree(tree_name, body):
     """Make a new tree."""
-    session = current_app.db.session('treestatus')
+    session = current_app.db.session('relengapi')
     if body.tree != tree_name:
         raise BadRequest("Tree names must match")
     t = model.DbTree(
@@ -181,7 +181,7 @@ def make_tree(tree_name, body):
 @apimethod(None, unicode)
 def kill_tree(tree):
     """Delete a tree."""
-    session = current_app.db.session('treestatus')
+    session = current_app.db.session('relengapi')
     t = session.query(model.DbTree).get(tree)
     if not t:
         raise NotFound("No such tree")
@@ -203,12 +203,12 @@ def get_logs(tree, all=0):
     5 entries by default.  Use `?all=1` to get all log entries.
     """
     # verify the tree exists first
-    t = current_app.db.session('treestatus').query(model.DbTree).get(tree)
+    t = current_app.db.session('relengapi').query(model.DbTree).get(tree)
     if not t:
         raise NotFound("No such tree")
 
     logs = []
-    q = current_app.db.session('treestatus').query(
+    q = current_app.db.session('relengapi').query(
         model.DbLog).filter_by(tree=tree)
     q = q.order_by(model.DbLog.when.desc())
     if not all:
@@ -238,7 +238,7 @@ def revert_change(id):
     This applies the settings that were present before the change to the
     affected trees, and deletes the change from the stack.
     """
-    session = current_app.db.session('treestatus')
+    session = current_app.db.session('relengapi')
     ch = session.query(model.DbStatusChange).get(id)
     if not ch:
         raise NotFound
@@ -266,7 +266,7 @@ def delete_change(id):
     """
     Delete the given change from the undo stack, without applying it.
     """
-    session = current_app.db.session('treestatus')
+    session = current_app.db.session('relengapi')
     ch = session.query(model.DbStatusChange).get(id)
     if not ch:
         raise NotFound
@@ -290,7 +290,7 @@ def update_trees(body):
 
     The `tags` property must not be empty if `status` is `closed`.
     """
-    session = current_app.db.session('treestatus')
+    session = current_app.db.session('relengapi')
     trees = [session.query(model.DbTree).get(t) for t in body.trees]
     if not all(trees):
         raise NotFound("one or more trees not found")

--- a/relengapi/blueprints/treestatus/model.py
+++ b/relengapi/blueprints/treestatus/model.py
@@ -20,7 +20,7 @@ from relengapi.blueprints.treestatus import types
 log = logging.getLogger(__name__)
 
 
-class DbTree(db.declarative_base('treestatus')):
+class DbTree(db.declarative_base('relengapi')):
     __tablename__ = 'treestatus_trees'
     tree = Column(String(32), primary_key=True)
     status = Column(String(64), default="open", nullable=False)
@@ -36,7 +36,7 @@ class DbTree(db.declarative_base('treestatus')):
         )
 
 
-class DbLog(db.declarative_base('treestatus')):
+class DbLog(db.declarative_base('relengapi')):
     __tablename__ = 'treestatus_log'
 
     id = Column(Integer, primary_key=True)
@@ -67,7 +67,7 @@ class DbLog(db.declarative_base('treestatus')):
         )
 
 
-class DbStatusChange(db.declarative_base('treestatus')):
+class DbStatusChange(db.declarative_base('relengapi')):
     __tablename__ = 'treestatus_changes'
     id = Column(Integer, primary_key=True)
     who = Column(Text, nullable=False)
@@ -86,7 +86,7 @@ class DbStatusChange(db.declarative_base('treestatus')):
         )
 
 
-class DbStatusChangeTree(db.declarative_base('treestatus')):
+class DbStatusChangeTree(db.declarative_base('relengapi')):
     __tablename__ = 'treestatus_change_trees'
     id = Column(Integer, primary_key=True)
     stack_id = Column(Integer, ForeignKey(DbStatusChange.id), index=True)

--- a/relengapi/blueprints/treestatus/model.py
+++ b/relengapi/blueprints/treestatus/model.py
@@ -43,7 +43,7 @@ class DbLog(db.declarative_base('treestatus')):
     tree = Column(String(32), nullable=False, index=True)
     when = Column(DateTime, nullable=False, index=True)
     who = Column(String(100), nullable=False)
-    action = Column(String(16), nullable=False)
+    action = Column(String(64), nullable=False)
     reason = Column(String(256), nullable=False)
     _tags = Column("tags", String(256), nullable=False)
 

--- a/relengapi/blueprints/treestatus/model.py
+++ b/relengapi/blueprints/treestatus/model.py
@@ -1,0 +1,131 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import json
+import logging
+
+from relengapi.lib import db
+from sqlalchemy import Boolean
+from sqlalchemy import Column
+from sqlalchemy import DateTime
+from sqlalchemy import ForeignKey
+from sqlalchemy import Integer
+from sqlalchemy import String
+from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.orm import relation
+
+from relengapi.blueprints.treestatus import types
+
+log = logging.getLogger(__name__)
+
+
+class DbTree(db.declarative_base('treestatus')):
+    __tablename__ = 'trees'
+    tree = Column(String(32), primary_key=True)
+    status = Column(String(64), default="open", nullable=False)
+    reason = Column(String(256), default="", nullable=False)
+    message_of_the_day = Column(String(800), default="", nullable=False)
+
+    def to_json(self):
+        return types.JsonTree(
+            tree=self.tree,
+            status=self.status,
+            reason=self.reason,
+            message_of_the_day=self.message_of_the_day,
+        )
+
+
+class DbLog(db.declarative_base('treestatus')):
+    __tablename__ = 'log'
+
+    id = Column(Integer, primary_key=True)
+    tree = Column(String(32), nullable=False, index=True)
+    when = Column(DateTime, nullable=False, index=True)
+    who = Column(String(100), nullable=False)
+    action = Column(String(16), nullable=False)
+    reason = Column(String(256), nullable=False)
+    _tags = Column("tags", String(256), nullable=False)
+
+    def __init__(self, tags=None, **kwargs):
+        if tags is not None:
+            kwargs['_tags'] = json.dumps(tags)
+        super(DbLog, self).__init__(**kwargs)
+
+    @hybrid_property
+    def tags(self):
+        return json.loads(self._tags)
+
+    @tags.setter
+    def set_tags(self, val):
+        self._tags = json.dumps(val)
+
+    def to_json(self):
+        return types.JsonTreeLog(
+            tree=self.tree,
+            when=self.when,
+            who=self.who,
+            action=self.action,
+            reason=self.reason,
+            tags=self.tags,
+        )
+
+
+class DbToken(db.declarative_base('treestatus')):
+    __tablename__ = 'tokens'
+    who = Column(String(100), nullable=False, primary_key=True)
+    token = Column(String(100), nullable=False)
+
+    @classmethod
+    def delete(cls, who):
+        q = cls.__table__.delete(cls.who == who)
+        q.execute()
+
+    @classmethod
+    def get(cls, who):
+        q = cls.__table__.select(cls.who == who)
+        result = q.execute().fetchone()
+        return result
+
+
+class DbStatusStack(db.declarative_base('treestatus')):
+    __tablename__ = 'status_stacks'
+    id = Column(Integer, primary_key=True)
+    who = Column(String(100), nullable=False)
+    reason = Column(String(256), nullable=False)
+    when = Column(DateTime, nullable=False, index=True)
+    status = Column(String(64), nullable=False)
+
+    def to_json(self):
+        return types.JsonStateChange(
+            trees=[t.tree for t in self.trees],
+            status=self.status,
+            when=self.when,
+            who=self.who,
+            reason=self.reason,
+            id=self.id,
+        )
+
+
+class DbStatusStackTree(db.declarative_base('treestatus')):
+    __tablename__ = 'status_stack_trees'
+    id = Column(Integer, primary_key=True)
+    stack_id = Column(Integer, ForeignKey(DbStatusStack.id), index=True)
+    tree = Column(String(32), nullable=False, index=True)
+    last_state = Column(String(1024), nullable=False)
+
+    stack = relation(DbStatusStack, backref='trees')
+
+
+class DbUser(db.declarative_base('treestatus')):
+    __tablename__ = "users"
+    id = Column(Integer, primary_key=True)
+    name = Column(String(100), index=True)
+    is_admin = Column(Boolean, nullable=False, default=False)
+    is_sheriff = Column(Boolean, nullable=False, default=False)
+
+    @classmethod
+    def get(cls, name):
+        q = cls.__table__.select(cls.name == name)
+        result = q.execute().fetchone()
+        return result

--- a/relengapi/blueprints/treestatus/static/footer.html
+++ b/relengapi/blueprints/treestatus/static/footer.html
@@ -1,0 +1,9 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+     License, v. 2.0. If a copy of the MPL was not distributed with this
+     file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<div id="footer">
+    <span class="footerWrapper">
+        <a href="/treestatus">All trees</a> &bull;
+        <a href="https://github.com/mozilla/relengapi">Source</a>
+    </span>
+</div>

--- a/relengapi/blueprints/treestatus/static/index.html
+++ b/relengapi/blueprints/treestatus/static/index.html
@@ -4,6 +4,10 @@
 <div ng-app='treestatus' id="treestatus" ng-controller="TreeListController">
     <div class="row">
         <div class="col-xs-12">
+            <div class="pull-right">
+                <button class="btn btn-default"
+                    ng-click="refresh()"><span class="glyphicon glyphicon-refresh">
+            </div>
             <h1 class="treestatus">TreeStatus</h1>
         </div>
     </div>
@@ -95,7 +99,7 @@
             </div>
         </div>
         <div class="col-xs-12 col-lg-4" ng-if="can_sheriff">
-            <tree-status-control trees="selected_trees" updated="treesUpdated()">
+            <tree-status-control trees="selected_trees" updated="refresh()">
             </tree-status-control>
         </div>
     </div>

--- a/relengapi/blueprints/treestatus/static/index.html
+++ b/relengapi/blueprints/treestatus/static/index.html
@@ -2,10 +2,6 @@
      License, v. 2.0. If a copy of the MPL was not distributed with this
      file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <div ng-app='treestatus' id="treestatus" ng-controller="TreeListController">
-    <div  class="pull-right">
-        <label><input type="checkbox" ng-model="can_admin" /> can admin</label> /
-        <label><input type="checkbox" ng-model="can_sheriff" /> can sheriff</label>
-    </div>
     <div class="row">
         <div class="col-xs-12">
             <h1 class="treestatus">TreeStatus</h1>
@@ -42,7 +38,7 @@
             <!-- change stack -->
             <div class="panel panel-primary" ng-if="can_sheriff && stack.length > 0">
                 <div class="panel-heading">
-                    <h3 class="panel-title">Revert Changes</h3>
+                    <h3 class="panel-title">Restore Changes</h3>
                 </div>
                 <div class="panel-body">
                     <ul class="list-group">
@@ -50,7 +46,7 @@
                             <div class="pull-right">
                                 <div class="btn-group" role="group" aria-label="options">
                                     <button ng-click="revertChange(st.id)"
-                                        class="btn btn-xs btn-success">Revert</button>
+                                        class="btn btn-xs btn-success">Restore</button>
                                     <button ng-click="discardChange(st.id)"
                                         class="btn btn-xs btn-warning">Discard</button>
                                 </div>
@@ -99,9 +95,7 @@
             </div>
         </div>
         <div class="col-xs-12 col-lg-4" ng-if="can_sheriff">
-            <tree-status-control plural="1"
-                update="updateTrees(status, reason, tags, remember)"
-                disabled="selected_trees.length == 0">
+            <tree-status-control trees="selected_trees" updated="treesUpdated()">
             </tree-status-control>
         </div>
     </div>

--- a/relengapi/blueprints/treestatus/static/index.html
+++ b/relengapi/blueprints/treestatus/static/index.html
@@ -1,0 +1,109 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+     License, v. 2.0. If a copy of the MPL was not distributed with this
+     file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<div ng-app='treestatus' id="treestatus" ng-controller="TreeListController">
+    <div  class="pull-right">
+        <label><input type="checkbox" ng-model="can_admin" /> can admin</label> /
+        <label><input type="checkbox" ng-model="can_sheriff" /> can sheriff</label>
+    </div>
+    <div class="row">
+        <div class="col-xs-12">
+            <h1 class="treestatus">TreeStatus</h1>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-xs-12" ng-class="{'col-lg-8': can_sheriff}">
+            <table>
+                <thead>
+                    <tr>
+                        <th class="tableCheck" ng-if="can_sheriff">
+                            <input type="checkbox" ng-checked="allChecked()"
+                                   ng-click="checkAllClicked()" />
+                        </th>
+                        <th class="tableName">Name</th>
+                        <th class="tableState">State</th>
+                        <th class="tableReason">Reason</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr ng-repeat="(tname, tree) in trees">
+                        <td class="tableCheck" ng-if="can_sheriff">
+                            <input type="checkbox" ng-model="_selected_trees[tname]">
+                        </td>
+                        <td class="tableName">
+                            <a href="/treestatus/details/{{tname|urlencode}}">{{tname}}</a>
+                        </td>
+                        <td class="tableState {{tree.status | status2class}}">
+                            {{tree.status|uppercase}}
+                        </td>
+                    <td class="tableReason" ng-bind-html="tree.reason|linkifyBugs"></td>
+                </tr>
+            </table>
+            <!-- change stack -->
+            <div class="panel panel-primary" ng-if="can_sheriff && stack.length > 0">
+                <div class="panel-heading">
+                    <h3 class="panel-title">Revert Changes</h3>
+                </div>
+                <div class="panel-body">
+                    <ul class="list-group">
+                        <li class="list-group-item" ng-repeat="st in stack">
+                            <div class="pull-right">
+                                <div class="btn-group" role="group" aria-label="options">
+                                    <button ng-click="revertChange(st.id)"
+                                        class="btn btn-xs btn-success">Revert</button>
+                                    <button ng-click="discardChange(st.id)"
+                                        class="btn btn-xs btn-warning">Discard</button>
+                                </div>
+                            </div>
+                            At {{st.when}} UTC, {{st.who|shortName}} changed
+                            <span ng-if="st.trees.length == 1">tree</span>
+                            <span ng-if="st.trees.length != 1">trees</span>
+                            <em>{{st.trees|list}}</em> to
+                            <span ng-bind="st.status|uppercase"
+                                class={{st.status|status2class}}></span>
+                            <span ng-if="st.reason != ''">with reason "{{st.reason}}"</span>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <!-- delete trees -->
+            <div class="panel panel-primary" ng-if="can_admin && selected_trees.length != 0">
+                <div class="panel-heading">
+                    <h3 class="panel-title">Delete Trees</h3>
+                </div>
+                <div class="panel-body">
+                    <button class="btn btn-block btn-danger"
+                            ng-disabled="selected_trees.length == 0"
+                            ng-click="deleteTrees()">
+                        Delete Selected Trees</button>
+                </div>
+            </div>
+            <!-- add trees -->
+            <div class="panel panel-primary" ng-if="can_admin && selected_trees.length == 0">
+                <div class="panel-heading">
+                    <h3 class="panel-title">Add Tree</h3>
+                </div>
+                <div class="panel-body">
+                    <form novalidate
+                        ng-submit="addTree(new_tree_name); new_tree_name = ''">
+                        <div class="input-group">
+                            <input type="text" placeholder="Tree Name"
+                                class="form-control" ng-model="new_tree_name" />
+                            <span class="input-group-btn">
+                                <button class="btn btn-primary"
+                                    ng-disabled="!new_tree_name">Add</button>
+                            </span>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+        <div class="col-xs-12 col-lg-4" ng-if="can_sheriff">
+            <tree-status-control plural="1"
+                update="updateTrees(status, reason, tags, remember)"
+                disabled="selected_trees.length == 0">
+            </tree-status-control>
+        </div>
+    </div>
+    <ng-include src="'/treestatus/static/footer.html'">
+</div>

--- a/relengapi/blueprints/treestatus/static/tree.html
+++ b/relengapi/blueprints/treestatus/static/tree.html
@@ -1,0 +1,68 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+     License, v. 2.0. If a copy of the MPL was not distributed with this
+     file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<div ng-app='treestatus' id="treestatus" ng-controller="TreeDetailController">
+    <div class="row">
+        <div class="col-xs-12">
+            <h2 class="treestatus">{{tree.tree}} status is
+                <span class="{{tree.status|status2class}}">{{tree.status|uppercase}}</span>
+            </h2><br/>
+            <h2 class="treestatus" ng-if="tree.reason">Reason:
+                <span ng-bind-html="tree.reason|linkifyBugs"></span></h2>
+            <h3 class="treestatus" ng-if="tree.message_of_the_day"
+                ng-bind-html="tree.message_of_the_day|linkifyBugs"></h3>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-xs-12" ng-class="{'col-lg-8': can_sheriff}">
+            <table class="history">
+                <thead>
+                    <tr>
+                        <th class="tableWho">User</th>
+                        <th class="tableWhen">Time</th>
+                        <th class="tableState">Action</th>
+                        <th class="tableReason">Reason</th>
+                        <th class="tableTags">Tags</th>
+                    </tr>
+                </thead>
+                <tbody>
+                <tr ng-repeat="log in logs">
+                    <td class="tableWho">{{log.who|shortName}}</td>
+                    <td class="tableWhen">{{log.when}} UTC</td>
+                    <td class="tableState {{log.action|status2class}}">
+                        {{log.action|uppercase}}
+                    </td>
+                    <td class="tableReason" ng-bind-html="log.reason|linkifyBugs"></td>
+                    <td class="tableTags">{{log.tags|list}}</td>
+                </tr>
+                <tfoot ng-hide="show_all_logs">
+                    <tr>
+                        <td colspan="5" class="text-center">
+                            <a ng-click="loadAllLogs()">More..</a>
+                        </td>
+                    </tr>
+                </tfoot>
+            </table>
+        </div>
+        <div class="col-xs-12 col-lg-4" ng-if="can_sheriff">
+            <tree-status-control update="updateTree(status, reason, tags, remember)">
+            </tree-status-control>
+            <div class="panel panel-primary">
+                <div class="panel-heading">
+                    <h3 class="panel-title">Message of the Day</h3>
+                </div>
+                <div class="panel-body">
+                    <div class="input-group" ng-if="can_sheriff">
+                        <input type="text" class="form-control" placeholder="message of the day"
+                               ng-model="new_motd" />
+                        <span class="input-group-btn">
+                            <button class="btn btn-default"
+                                    ng-click="setMotd(new_motd)">Set MOTD</button>
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <ng-include src="'/treestatus/static/footer.html'"></ng-include>
+</div>

--- a/relengapi/blueprints/treestatus/static/tree.html
+++ b/relengapi/blueprints/treestatus/static/tree.html
@@ -29,8 +29,8 @@
                 <tr ng-repeat="log in logs">
                     <td class="tableWho">{{log.who|shortName}}</td>
                     <td class="tableWhen">{{log.when}} UTC</td>
-                    <td class="tableState {{log.action|status2class}}">
-                        {{log.action|uppercase}}
+                    <td class="tableState {{log.status|status2class}}">
+                        {{log.status|uppercase}}
                     </td>
                     <td class="tableReason" ng-bind-html="log.reason|linkifyBugs"></td>
                     <td class="tableTags">{{log.tags|list}}</td>

--- a/relengapi/blueprints/treestatus/static/tree.html
+++ b/relengapi/blueprints/treestatus/static/tree.html
@@ -4,6 +4,10 @@
 <div ng-app='treestatus' id="treestatus" ng-controller="TreeDetailController">
     <div class="row">
         <div class="col-xs-12">
+            <div class="pull-right">
+                <button class="btn btn-default"
+                    ng-click="refresh()"><span class="glyphicon glyphicon-refresh">
+            </div>
             <h2 class="treestatus">{{tree.tree}} status is
                 <span class="{{tree.status|status2class}}">{{tree.status|uppercase}}</span>
             </h2><br/>
@@ -45,7 +49,7 @@
             </table>
         </div>
         <div class="col-xs-12 col-lg-4" ng-if="can_sheriff">
-            <tree-status-control trees="[tree.tree]" updated="treeUpdated()">
+            <tree-status-control trees="[tree.tree]" updated="refresh()">
             </tree-status-control>
         </div>
     </div>

--- a/relengapi/blueprints/treestatus/static/tree.html
+++ b/relengapi/blueprints/treestatus/static/tree.html
@@ -45,23 +45,8 @@
             </table>
         </div>
         <div class="col-xs-12 col-lg-4" ng-if="can_sheriff">
-            <tree-status-control update="updateTree(status, reason, tags, remember)">
+            <tree-status-control trees="[tree.tree]" updated="treeUpdated()">
             </tree-status-control>
-            <div class="panel panel-primary">
-                <div class="panel-heading">
-                    <h3 class="panel-title">Message of the Day</h3>
-                </div>
-                <div class="panel-body">
-                    <div class="input-group" ng-if="can_sheriff">
-                        <input type="text" class="form-control" placeholder="message of the day"
-                               ng-model="new_motd" />
-                        <span class="input-group-btn">
-                            <button class="btn btn-default"
-                                    ng-click="setMotd(new_motd)">Set MOTD</button>
-                        </span>
-                    </div>
-                </div>
-            </div>
         </div>
     </div>
     <ng-include src="'/treestatus/static/footer.html'"></ng-include>

--- a/relengapi/blueprints/treestatus/static/treeStatusControl.html
+++ b/relengapi/blueprints/treestatus/static/treeStatusControl.html
@@ -1,0 +1,54 @@
+<div class="panel panel-primary">
+    <div class="panel-heading">
+        <h3 class="panel-title" ng-if="!plural">Update Tree</h3>
+        <h3 class="panel-title" ng-if="plural">Update Trees</h3>
+    </div>
+    <div class="panel-body">
+        <form name="tsForm" novalidate ng-submit="submit()">
+            <div class="form-group">
+                <label for="status">New Tree Status</label>
+                <select name="status" class="form-control"
+                    ng-model="status" ng-options="st for st in allowed_statuses">
+                </select>
+            </div>
+            <div class="form-group">
+                <label>Tags</label>
+                <span ng-if="status == 'closed'" class="text-muted">(required to close)</span>
+                <div ng-repeat="(tag, descr) in allowed_tags" class="checkbox">
+                    <label>
+                            <input ng-model="tags[tag]" type="checkbox" />{{descr}}
+                    </label>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="reason">Reason for Change</label>
+                <span ng-if="status == 'closed'" class="text-muted">(required to close)</span>
+                <ul>
+                    <li class="small">Please indicate the reason for closure,
+                        preferably with a bug link</li>
+                    <li class="small">Please indicate conditions for reopening,
+                        especially if you might disappear before reopening the
+                        tree yourself.</li>
+                </ul>
+                <input type="text" name="reason" class="form-control"
+                    placeholder="reason" ng-model="reason" ng-required="status == 'closed'">
+            </div>
+            <div class="form-group">
+                <label for="remember">Remember Change</label>
+                <div class="checkbox">
+                    <label>
+                        <input ng-model="remember" type="checkbox" />
+                        Remember this change to undo later
+                    </label>
+                </div>
+            </div>
+            <div class="form-group">
+                <!-- TODO: add an "=disabled" to disable this externally (when
+                     nothing's checked) -->
+                <button ng-disabled="tsForm.$invalid || formInvalid() || disabled"
+                        class="btn btn-block btn-primary">Update
+                        <span ng-if="plural">Selected Trees</span></button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/relengapi/blueprints/treestatus/static/treeStatusControl.html
+++ b/relengapi/blueprints/treestatus/static/treeStatusControl.html
@@ -6,17 +6,18 @@
     <div class="panel-body">
         <form name="tsForm" novalidate ng-submit="submit()">
             <div class="form-group">
-                <label for="status">New Tree Status</label>
+                <label for="status">Change Tree Status</label>
                 <select name="status" class="form-control"
                     ng-model="status" ng-options="st for st in allowed_statuses">
                 </select>
             </div>
             <div class="form-group">
-                <label>Tags</label>
+                <label>Tags for Change</label>
                 <span ng-if="status == 'closed'" class="text-muted">(required to close)</span>
                 <div ng-repeat="(tag, descr) in allowed_tags" class="checkbox">
                     <label>
-                            <input ng-model="tags[tag]" type="checkbox" />{{descr}}
+                            <input ng-model="tags[tag]" type="checkbox"
+                                   ng-disabled="!status"/>{{descr}}
                     </label>
                 </div>
             </div>
@@ -31,23 +32,29 @@
                         tree yourself.</li>
                 </ul>
                 <input type="text" name="reason" class="form-control"
-                    placeholder="reason" ng-model="reason" ng-required="status == 'closed'">
+                    placeholder="(no reason)" ng-model="reason"
+                    ng-required="status == 'closed'"
+                    ng-disabled="!status" />
             </div>
             <div class="form-group">
                 <label for="remember">Remember Change</label>
                 <div class="checkbox">
                     <label>
-                        <input ng-model="remember" type="checkbox" />
+                        <input ng-model="remember" type="checkbox"
+                            ng-disabled="!status" />
                         Remember this change to undo later
                     </label>
                 </div>
             </div>
+            <hr />
             <div class="form-group">
-                <!-- TODO: add an "=disabled" to disable this externally (when
-                     nothing's checked) -->
-                <button ng-disabled="tsForm.$invalid || formInvalid() || disabled"
-                        class="btn btn-block btn-primary">Update
-                        <span ng-if="plural">Selected Trees</span></button>
+                <label for="reason">Message of the Day</label>
+                <input type="text" name="reason" class="form-control"
+                    placeholder="(no change)" ng-model="message_of_the_day">
+            </div>
+            <div class="form-group">
+                <button ng-disabled="!updateIsValid()"
+                        class="btn btn-block btn-primary">Update<query/span></button>
             </div>
         </form>
     </div>

--- a/relengapi/blueprints/treestatus/static/treestatus.css
+++ b/relengapi/blueprints/treestatus/static/treestatus.css
@@ -95,9 +95,5 @@ h1.treestatus {
 
 
 #footer {
-    position: absolute;
-    bottom: 0;
-    width: 100%;
     text-align: center;
-    height: 60px;
 }

--- a/relengapi/blueprints/treestatus/static/treestatus.css
+++ b/relengapi/blueprints/treestatus/static/treestatus.css
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@font-face {
+    font-family: 'Open sans';
+    font-style: normal;
+    font-weight: 400;
+    src: local('Open sans') url('/static/opensans.woff');
+}
+
+#treestatus {
+    font-family: sans-serif;
+}
+
+h1.treestatus,
+h2.treestatus,
+h3.treestatus {
+    color: rgb(72,72,72);
+    font-family: 'Open sans', sans-serif;
+    font-weight: bold;
+    text-align: center;
+}
+
+h1.treestatus {
+    font-size: 300%;
+}
+
+#treestatus table {
+    margin-left: auto;
+    margin-right: auto;
+    border-collapse: collapse;
+    min-width: 720px;
+    margin-bottom: 40px;
+}
+
+#treestatus thead {
+    background-color: #0095dd;
+    color: white;
+    font-family: 'Open sans', sans-serif;
+    text-align: left;
+}
+
+#treestatus th {
+    padding: 5px;
+}
+
+#treestatus tr {
+    border-top: 1px solid gray;
+}
+
+#treestatus td {
+    padding-top: 5px;
+    padding-bottom: 5px;
+}
+
+#treestatus thead > tr {
+    border: none;
+}
+
+#treestatus a {
+    color:#2983c8;
+    text-decoration:none
+}
+
+#treestatus a:hover, #treestatus a:active{
+    color:#20679e;
+    text-decoration:underline;
+}
+
+#treestatus a:hover.loginout, a:active.loginout {
+    color: white;
+    text-decoration: none;
+}
+
+.tableCheck {
+    min-width: 20px;
+}
+
+.tableName {
+    min-width: 200px;
+}
+
+.tableState {
+    min-width: 100px;
+}
+
+.tableReason {
+    min-width: 400px;
+}
+
+.tableTree {
+    min-width: 200px;
+}
+
+
+#footer {
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+    text-align: center;
+    height: 60px;
+}

--- a/relengapi/blueprints/treestatus/static/treestatus.js
+++ b/relengapi/blueprints/treestatus/static/treestatus.js
@@ -1,0 +1,371 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+angular.module('treestatus', ['relengapi', 'initial_data']);
+
+// constants defining the tool's behavior
+
+angular.module('treestatus').constant('allowed_statuses', [
+    'closed',
+    'open',
+    'approval required'
+]);
+
+angular.module('treestatus').constant('allowed_tags', {
+    'checkin-compilation': 'Check-in compilation failure',
+    'checkin-test': 'Check-in test failure',
+    'infra': 'Infrastructure related',
+    'backlog': 'Job backlog',
+    'planned': 'Planned closure',
+    'other': 'Other',
+});
+
+
+// some useful filters for the template
+
+angular.module('treestatus').filter('urlencode', function() {
+    return window.encodeURIComponent;
+});
+
+// convert a tree status to a CSS class name
+angular.module('treestatus').filter('status2class', function() {
+    return function(input) {
+        return input.toLowerCase().replace(" ", "_", "g");
+    };
+});
+
+// shorten a user identity
+angular.module('treestatus').filter('shortName', function() {
+    var domain_re = /@.*/;
+    var human_re = /^human:/;
+    return function(input) {
+        return input.replace(domain_re, '').replace(human_re, '');
+    };
+});
+
+// make an array into a comma-separated list
+angular.module('treestatus').filter('list', function() {
+    return function(input) {
+        return input.join(", ");
+    };
+});
+
+// borrowed from https://github.com/mozilla/treeherder/blob/d5ae8deb9f041ce538eee1a5d8d05c60f09e56be/ui/js/filters.js#L40-L71
+angular.module('treestatus').filter('linkifyBugs', function($sce) {
+    return function(input) {
+        // perform some basic sanitization
+        var str = (input || '')
+            .replace('<', '&lt;')
+            .replace('>', '&gt;')
+            .replace('&', '&amp;');
+
+        var bug_matches = str.match(/-- ([0-9]+)|bug.([0-9]+)/ig);
+        var pr_matches = str.match(/PR#([0-9]+)/ig);
+
+        // Settings
+        var bug_title = 'bugzilla.mozilla.org';
+        var bug_url = '<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=$1" ' +
+            'data-bugid=$1 ' + 'title=' + bug_title + '>$1</a>';
+        var pr_title = 'github.com';
+        var pr_url = '<a href="https://github.com/mozilla-b2g/gaia/pull/$1" ' +
+            'data-prid=$1 ' + 'title=' + pr_title + '>$1</a>';
+
+        if (bug_matches) {
+            // Separate passes to preserve prefix
+            str = str.replace(/Bug ([0-9]+)/g, "Bug " + bug_url);
+            str = str.replace(/bug ([0-9]+)/g, "bug " + bug_url);
+            str = str.replace(/-- ([0-9]+)/g, "-- " + bug_url);
+        }
+
+        if (pr_matches) {
+            // Separate passes to preserve prefix
+            str = str.replace(/PR#([0-9]+)/g, "PR#" + pr_url);
+            str = str.replace(/pr#([0-9]+)/g, "pr#" + pr_url);
+        }
+
+        return $sce.trustAsHtml(str);
+    };
+});
+
+// Directives
+
+// Input panel for updating trees; the "update" attribute is evaluated with
+// `status`, `reason`, `tags`, and `remember` set when the form is submitted.
+// Set `plural="1"` for a form that can affect multiple trees.  The `disabled`
+// attribute gives an expression to disable the whole form (e.g., when no
+// trees are selected)
+angular.module('treestatus').directive('treeStatusControl',
+function(allowed_statuses, allowed_tags) {
+    return {
+        restrict: 'E',
+        replace: true,
+        templateUrl: '/treestatus/static/treeStatusControl.html',
+        scope: {
+            disabled: '=disabled',
+            update: '&update',
+            plural: '@plural',
+        },
+        link: function(scope, element, attrs, ctrl) {
+            scope.allowed_statuses = allowed_statuses;
+            scope.allowed_tags = allowed_tags;
+
+            scope.status = allowed_statuses[0];
+            scope.tags = {};
+            scope.reason = "";
+            scope.remember = true;
+
+            // ngModel handles tags as an object with boolean values, so
+            // convert it to an array of tag names as the API expects
+            var tagList = function(model) {
+                var tags = [];
+                angular.forEach(model, function(present, tag) {
+                    if (present) {
+                        tags.push(tag);
+                    }
+                });
+                tags.sort();
+                return tags;
+            };
+
+            // we do some whole-form validation per business rules
+            scope.formInvalid = function() {
+                if (scope.status == 'closed' && tagList(scope.tags).length == 0) {
+                    return true;
+                }
+                return false;
+            };
+
+            scope.submit = function() {
+                scope.update({
+                    status: scope.status,
+                    reason: scope.reason,
+                    tags: tagList(scope.tags),
+                    remember: scope.remember,
+                });
+                // reset the form
+                scope.tags = {};
+                scope.reason = '';
+            };
+        },
+    };
+});
+
+// Controllers
+
+// index.html
+angular.module('treestatus').controller('TreeListController',
+                                    function($scope, restapi, initial_data, $q) {
+    $scope.trees = initial_data.trees;
+    $scope.stack = initial_data.stack;
+
+    // Pre-flight some permissions
+    var perms = initial_data.user.permissions
+    $scope.can_sheriff = perms.some(function(perm) {
+        return perm.name == 'treestatus.sheriff';
+    });
+    $scope.can_admin = perms.some(function(perm) {
+        return perm.name == 'treestatus.admin';
+    });
+
+    $scope.new_tree_name = '';
+
+    // checkboxes create an object with boolean keys, but we want a list
+    // of tree names
+    $scope.selected_trees = [];
+    $scope._selected_trees = {};
+    $scope.$watchCollection('_selected_trees', function(newValue) {
+        var trees = $scope.selected_trees = [];
+        angular.forEach(newValue, function(present, tree) {
+            if (present) {
+                trees.push(tree);
+            }
+        });
+        trees.sort();
+    });
+
+    var reloadTrees = function() {
+        restapi.get('/treestatus/trees', {
+            while: 'fetching tree data',
+        }).then(function (data, status, headers, config) {
+            $scope.trees = data.data.result;
+        });
+    };
+
+    var reloadStack = function() {
+        restapi.get('/treestatus/stack', {
+            while: 'fetching undo stack data',
+        }).then(function (data, status, headers, config) {
+            $scope.stack = data.data.result;
+        });
+    };
+
+    // handle the check-all checkbox
+    $scope.allChecked = function() {
+        var all_checked = true;
+        angular.forEach($scope.trees, function(tree, name) {
+            if (!$scope._selected_trees[name]) {
+                all_checked = false;
+            }
+        });
+        return all_checked;
+    };
+
+    $scope.checkAllClicked = function() {
+        var newVal = !$scope.allChecked();
+        angular.forEach($scope.trees, function(tree, name) {
+            $scope._selected_trees[name] = newVal;
+        });
+    };
+
+    $scope.revertChange = function(stack_id) {
+        restapi({
+            url: '/treestatus/stack/' + stack_id,
+            method: 'REVERT',
+            while: 'reverting change',
+        }).then(function (data, status, headers, config) {
+            reloadTrees();
+            reloadStack();
+        });
+    };
+
+    $scope.discardChange = function(stack_id) {
+        restapi({
+            url: '/treestatus/stack/' + stack_id,
+            method: 'DELETE',
+            while: 'deleting change',
+        }).then(function (data, status, headers, config) {
+            reloadStack();
+        });
+    };
+
+    $scope.addTree = function(treename) {
+        restapi({
+            url: '/treestatus/trees/' + treename,
+            method: 'PUT',
+            data: JSON.stringify({
+                tree: treename,
+                status: 'closed',
+                reason: 'new tree',
+                message_of_the_day: '',
+            }),
+            headers: {'Content-Type': 'application/json'},
+            while: 'adding tree ' + treename,
+        }).then(function() {
+            reloadTrees();
+        });
+    };
+
+    $scope.deleteTrees = function() {
+        var promises = [];
+        angular.forEach($scope.selected_trees, function(treename) {
+            promises.push(restapi({
+                url: '/treestatus/trees/' + treename,
+                method: 'DELETE',
+                while: 'deleting tree ' + treename,
+            }));
+        });
+
+        $q.all(promises).then(function() {
+            $scope._selected_trees = {};
+            reloadTrees();
+            reloadStack();
+        });
+    };
+
+    $scope.updateTrees = function(status, reason, tags, remember) {
+        var update = {
+            trees: $scope.selected_trees,
+            status: status,
+            reason: reason,
+            tags: tags,
+            remember: remember,
+        };
+        restapi({
+            url: '/treestatus/trees',
+            method: 'UPDATE',
+            data: JSON.stringify(update),
+            headers: {'Content-Type': 'application/json'},
+            while: 'updating tree',
+        }).then(function (data, status, headers, config) {
+            reloadTrees();
+            reloadStack();
+        });
+    };
+});
+
+// tree.html
+angular.module('treestatus').controller('TreeDetailController',
+                                    function($scope, restapi, initial_data) {
+    $scope.tree = initial_data.tree;
+    $scope.logs = initial_data.logs;
+    $scope.show_all_logs = false;
+
+    $scope.new_motd = $scope.tree.message_of_the_day;
+
+    // Pre-flight some permissions
+    var perms = initial_data.user.permissions
+    $scope.can_sheriff = perms.some(function(perm) {
+        return perm.name == 'treestatus.sheriff';
+    });
+
+    var treename = $scope.tree.tree;
+
+    var reloadLogs = function() {
+        var all_ext = $scope.show_all_logs ? '?all=1' : '';
+        restapi.get('/treestatus/trees/' + treename + '/logs' + all_ext, {
+            while: 'fetching more logs',
+        }).then(function (data, status, headers, config) {
+            $scope.logs = data.data.result;
+        });
+    };
+
+    var reloadTree = function() {
+        restapi.get('/treestatus/trees/' + treename, {
+            while: 'fetching tree data',
+        }).then(function (data, status, headers, config) {
+            $scope.tree = data.data.result;
+        });
+    };
+
+    $scope.loadAllLogs = function() {
+        $scope.show_all_logs = true;
+        reloadLogs();
+    };
+
+    $scope.setMotd = function(new_motd) {
+        restapi({
+            url: '/treestatus/trees/' + treename,
+            method: 'PATCH',
+            data: JSON.stringify({
+                tree: treename,
+                status: $scope.tree.status,
+                reason: $scope.tree.reason,
+                message_of_the_day: new_motd,
+            }),
+            while: 'updating message of the day',
+        }).then(function (data, status, headers, config) {
+            $scope.tree.message_of_the_day = new_motd;
+        });
+    };
+
+    $scope.updateTree = function(status, reason, tags, remember) {
+        var update = {
+            trees: [treename],
+            status: status,
+            reason: reason,
+            tags: tags,
+            remember: remember,
+        };
+        restapi({
+            url: '/treestatus/trees',
+            method: 'UPDATE',
+            data: JSON.stringify(update),
+            headers: {'Content-Type': 'application/json'},
+            while: 'updating tree',
+        }).then(function (data, status, headers, config) {
+            reloadLogs();
+            reloadTree();
+        });
+    };
+});

--- a/relengapi/blueprints/treestatus/static/treestatus.js
+++ b/relengapi/blueprints/treestatus/static/treestatus.js
@@ -328,7 +328,7 @@ angular.module('treestatus').controller('TreeListController',
         });
     };
 
-    $scope.treesUpdated = function() {
+    $scope.refresh = function() {
         reloadTrees();
         reloadStack();
     };
@@ -373,7 +373,7 @@ angular.module('treestatus').controller('TreeDetailController',
         reloadLogs();
     };
 
-    $scope.treeUpdated = function() {
+    $scope.refresh = function() {
         reloadLogs();
         reloadTree();
     };

--- a/relengapi/blueprints/treestatus/test_treestatus.py
+++ b/relengapi/blueprints/treestatus/test_treestatus.py
@@ -1,0 +1,628 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import datetime
+import mock
+import pprint
+
+from contextlib import contextmanager
+from flask import json
+from nose.tools import eq_
+from relengapi import p
+from relengapi.blueprints.treestatus import model
+from relengapi.lib import auth
+from relengapi.lib.testing.context import TestContext
+
+
+tree1_json = {
+    'tree': 'tree1',
+    'status': 'closed',
+    'reason': 'because',
+    'message_of_the_day': 'enjoy troy',
+}
+
+
+def db_setup(app):
+    session = app.db.session('treestatus')
+    tree = model.DbTree(
+        tree=tree1_json['tree'],
+        status=tree1_json['status'],
+        reason=tree1_json['reason'],
+        message_of_the_day=tree1_json['message_of_the_day'])
+    session.add(tree)
+
+    def when(day):
+        return datetime.datetime(2015, 7, day, 17, 44, 00)
+    for tree, action, when, reason, tags in [
+        ('tree1', 'opened', when(13), 'i wanted to', ['a']),
+        ('tree1', 'opened', when(15), 'i really wanted to', []),
+        ('tree1', 'closed', when(14), 'because', ['a', 'b']),
+        ('tree2', 'approval required', when(11), 'so there', []),
+    ]:
+        l = model.DbLog(
+            tree=tree,
+            when=when,
+            who='dustin',
+            action=action,
+            reason=reason,
+            tags=tags)
+        session.add(l)
+        when += datetime.timedelta(days=1)
+    session.commit()
+
+
+def db_setup_stack(app):
+    for tn in range(3):
+        session = app.db.session('treestatus')
+        tree = model.DbTree(
+            tree='tree%d' % tn,
+            status='closed',
+            reason=['bug 123', 'bug 456', 'bug 456'][tn],
+            message_of_the_day='tree %d' % tn)
+        session.add(tree)
+
+    def ls(status, reason):
+        return json.dumps({'status': status, 'reason': reason})
+
+    # first change closed tree0 and tree1
+    stack = model.DbStatusStack(
+        who='dustin', reason='bug 123', status='closed',
+        when=datetime.datetime(2015, 7, 14))
+    session.add(stack)
+    for tree in 'tree0', 'tree1':
+        session.add(model.DbStatusStackTree(tree=tree, stack=stack,
+                                            last_state=ls('open', tree)))
+
+    # second change closed tree1 and tree2
+    stack = model.DbStatusStack(
+        who='dustin', reason='bug 456', status='closed',
+        when=datetime.datetime(2015, 7, 16))
+    session.add(stack)
+    session.add(model.DbStatusStackTree(tree='tree1', stack=stack,
+                                        last_state=ls('closed', 'bug 123')))
+    session.add(model.DbStatusStackTree(tree='tree2', stack=stack,
+                                        last_state=ls('open', 'tree2')))
+
+    session.commit()
+
+
+def userperms(perms, email='user@domain.com'):
+    u = auth.HumanUser(email)
+    u._permissions = set(perms)
+    return u
+
+admin_and_sheriff = userperms([p.treestatus.admin, p.treestatus.sheriff])
+admin = userperms([p.treestatus.admin])
+sheriff = userperms([p.treestatus.sheriff])
+
+test_context = TestContext(databases=['treestatus'],
+                           db_setup=db_setup)
+
+
+@contextmanager
+def set_time(now):
+    with mock.patch('relengapi.lib.time.now') as fake_now:
+        fake_now.return_value = now
+        yield
+
+
+def assert_logged(app, tree, action, reason, when=None,
+                  who='human:user@domain.com', tags=[]):
+    with app.app_context():
+        session = app.db.session('treestatus')
+        q = session.query(model.DbLog)
+        q = q.filter_by(tree=tree)
+        q = q.order_by(model.DbLog.when)
+        logs = q[:]
+        for l in logs:
+            if l.action != action:
+                continue
+            if l.reason != reason:
+                continue
+            if when and l.when != when:
+                continue
+            if l.who != who:
+                continue
+            if l.tags != tags:
+                continue
+            return  # success!
+        pprint.pprint([l.__dict__ for l in logs])
+        raise AssertionError("no matching log")
+
+
+@test_context
+def test_index_view(client):
+    """Getting /treestatus/ results in an index page"""
+    resp = client.get('/treestatus/')
+    assert 'TreeListController' in resp.data
+
+
+@test_context
+def test_tree_view(client):
+    """Getting /treestatus/tree1 results in a tree detail page"""
+    resp = client.get('/treestatus/details/tree1')
+    assert 'TreeDetailController' in resp.data
+
+
+@test_context
+def test_get_trees(client):
+    """Getting /treestatus/trees results in a dictionary of trees keyed by
+    name"""
+    resp = client.get('/treestatus/trees')
+    eq_(json.loads(resp.data)['result'], {'tree1': tree1_json})
+
+
+@test_context
+def test_get_tree(client):
+    """Getting /treestatus/trees/tree1 results in the tree data"""
+    resp = client.get('/treestatus/trees/tree1')
+    eq_(json.loads(resp.data)['result'], tree1_json)
+
+
+@test_context
+def test_get_tree_nosuch(client):
+    """Getting /treestatus/trees/NOSUCH results in a 404"""
+    resp = client.get('/treestatus/trees/NOSUCH')
+    eq_(resp.status_code, 404)
+
+
+@test_context.specialize(user=admin)
+def test_make_tree(client):
+    """Creating a tree makes a new tree with supplied values"""
+    resp = client.put('/treestatus/trees/newtree', data=json.dumps(
+        dict(tree='newtree', status='open', reason='green',
+             message_of_the_day='look right or say goodnight')),
+        headers=[('Content-Type', 'application/json')])
+    eq_(resp.status_code, 204)
+    resp = client.get('/treestatus/trees/newtree')
+    eq_(json.loads(resp.data)['result'], dict(tree='newtree', status='open', reason='green',
+                                              message_of_the_day='look right or say goodnight'))
+
+
+@test_context.specialize(user=sheriff)
+def test_make_tree_forbidden(client):
+    """Creating a tree without admin privs fails"""
+    resp = client.put('/treestatus/trees/tree9', data=json.dumps(
+        dict(tree='tree9', status='open', reason='green',
+             message_of_the_day='look right or say goodnight')),
+        headers=[('Content-Type', 'application/json')])
+    eq_(resp.status_code, 403)
+
+
+@test_context.specialize(user=admin)
+def test_make_tree_wrong_name(client):
+    """Creating a tree with a different name in the path and the body fails"""
+    resp = client.put('/treestatus/trees/sometree', data=json.dumps(
+        dict(tree='othertree', status='open', reason='green',
+             message_of_the_day='look right or say goodnight')),
+        headers=[('Content-Type', 'application/json')])
+    eq_(resp.status_code, 400)
+
+
+@test_context.specialize(user=admin)
+def test_make_tree_dup_name(client):
+    """Creating a tree with an existing name fails"""
+    resp = client.get('/treestatus/trees/tree1')
+    eq_(resp.status_code, 200)
+    resp = client.put('/treestatus/trees/tree1', data=json.dumps(
+        dict(tree='tree1', status='open', reason='green',
+             message_of_the_day='look right or say goodnight')),
+        headers=[('Content-Type', 'application/json')])
+    eq_(resp.status_code, 400)
+
+
+@test_context.specialize(user=admin)
+def test_delete_tree(client):
+    """Deleting a tree .. deletes the tree"""
+    resp = client.get('/treestatus/trees/tree1')
+    eq_(resp.status_code, 200)
+    resp = client.delete('/treestatus/trees/tree1')
+    eq_(resp.status_code, 204)
+    resp = client.get('/treestatus/trees/tree1')
+    eq_(resp.status_code, 404)
+
+
+@test_context.specialize(user=sheriff)
+def test_delete_tree_no_perms(client):
+    """Deleting a tree without admin perms fails"""
+    resp = client.delete('/treestatus/trees/tree1')
+    eq_(resp.status_code, 403)
+
+
+@test_context.specialize(user=admin)
+def test_delete_tree_nosuch(client):
+    """Deleting a tree that does not exist fails"""
+    resp = client.delete('/treestatus/trees/99999')
+    eq_(resp.status_code, 404)
+
+
+@test_context.specialize(user=sheriff)
+def test_modify_tree(client):
+    """Modifying a tree changes its message_of_the_day"""
+    resp = client.patch('/treestatus/trees/tree1', data=json.dumps(
+        dict(tree='tree1', status='closed', reason='because',
+             message_of_the_day="if it don't fit force it")),
+        headers=[('Content-Type', 'application/json')])
+    eq_(resp.status_code, 204)
+    resp = client.get('/treestatus/trees/tree1')
+    eq_(json.loads(resp.data)['result'], dict(tree='tree1', status='closed', reason='because',
+                                              message_of_the_day="if it don't fit force it"))
+
+
+@test_context.specialize(user=admin)
+def test_modify_tree_no_perms(client):
+    """Modifying a tree without sheriff perms fails"""
+    resp = client.patch('/treestatus/trees/tree1', data=json.dumps(
+        dict(tree='tree1', status='closed', reason='because',
+             message_of_the_day="if it don't fit force it")),
+        headers=[('Content-Type', 'application/json')])
+    eq_(resp.status_code, 403)
+
+
+@test_context.specialize(user=sheriff)
+def test_modify_tree_nosuch(client):
+    """Modifying a tree that does not exist returns a 404 error"""
+    resp = client.patch('/treestatus/trees/nosuch', data=json.dumps(
+        dict(tree='tree1', status='closed', reason='because',
+             message_of_the_day="if it don't fit force it")),
+        headers=[('Content-Type', 'application/json')])
+    eq_(resp.status_code, 404)
+
+
+@test_context.specialize(user=sheriff)
+def test_modify_tree_invalid_field(client):
+    """Modifying a tree's name, status, or reason fails."""
+    def mod(**mods):
+        d = tree1_json.copy()
+        d.update(mods)
+        return d
+    for t in [mod(tree='tree2'), mod(status='open'), mod(reason='i said so')]:
+        resp = client.patch('/treestatus/trees/tree1',
+                            data=json.dumps(t),
+                            headers=[('Content-Type', 'application/json')])
+        eq_(resp.status_code, 400)
+
+
+@test_context
+def test_get_logs(client):
+    """Getting /treestatus/trees/tree1/logs results in a sorted list of log
+    entries (newest first)"""
+    resp = client.get('/treestatus/trees/tree1/logs')
+    eq_(json.loads(resp.data)['result'], [{
+        'tree': 'tree1',
+        'tags': [],
+        'who': 'dustin',
+        'when': '2015-07-15T17:44:00',
+        'reason': 'i really wanted to',
+        'action': 'opened',
+    }, {
+        'tree': 'tree1',
+        'tags': ['a', 'b'],
+        'who': 'dustin',
+        'when': '2015-07-14T17:44:00',
+        'reason': 'because',
+        'action': 'closed',
+    }, {
+        'tree': 'tree1',
+        'tags': ['a'],
+        'who': 'dustin',
+        'when': '2015-07-13T17:44:00',
+        'reason': 'i wanted to',
+        'action': 'opened',
+    }
+    ])
+
+
+@test_context
+def test_get_logs_all(client, app):
+    """Getting /treestatus/trees/tree1/logs with over 5 logs present
+    results in only 5 logs, unless given ?all=1"""
+    # add the log entries
+    session = app.db.session('treestatus')
+    for ln in range(5):
+        l = model.DbLog(
+            tree='tree1',
+            when=datetime.datetime(2015, 6, 15, 17, 44, 00),
+            who='jimmy',
+            action='halfopen',
+            reason='being difficult',
+            tags=[])
+        session.add(l)
+    session.commit()
+
+    resp = client.get('/treestatus/trees/tree1/logs')
+    eq_(len(json.loads(resp.data)['result']), 5)
+
+    resp = client.get('/treestatus/trees/tree1/logs?all=1')
+    eq_(len(json.loads(resp.data)['result']), 8)
+
+
+@test_context
+def test_get_logs_nosuch(client):
+    """Getting /treestatus/trees/NOSUCH/logs results in a 404"""
+    resp = client.get('/treestatus/trees/NOSUCH/logs')
+    eq_(resp.status_code, 404)
+
+
+@test_context.specialize(db_setup=db_setup_stack)
+def test_get_stack(client):
+    """Getting /treestatus/stack gets the list of changes, most recent first"""
+    resp = client.get('/treestatus/stack')
+    res = json.loads(resp.data)
+    # sort the tree lists, since order isn't specified
+    res['result'][0]['trees'].sort()
+    res['result'][1]['trees'].sort()
+    eq_(res['result'], [{
+        'id': 2,
+        'trees': ['tree1', 'tree2'],
+        'when': '2015-07-16T00:00:00',
+        'who': 'dustin',
+        'reason': 'bug 456',
+        'status': 'closed',
+    }, {
+        'id': 1,
+        'trees': ['tree0', 'tree1'],
+        'who': 'dustin',
+        'when': '2015-07-14T00:00:00',
+        'reason': 'bug 123',
+        'status': 'closed',
+    }
+    ])
+
+
+@test_context.specialize(db_setup=db_setup_stack, user=sheriff)
+def test_revert_stack(app, client):
+    """REVERTing /treestatus/stack/N undoes the effects of that change and removes
+    it from the stack"""
+    resp = client.open('/treestatus/stack/2', method='REVERT')
+    eq_(resp.status_code, 204)
+
+    resp = client.get('/treestatus/trees')
+    updated_status = sorted([(t['tree'], t['status'], t['reason'])
+                             for t in json.loads(resp.data)['result'].values()])
+    eq_(updated_status, [
+        ('tree0', 'closed', 'bug 123'),
+        ('tree1', 'closed', 'bug 123'),
+        ('tree2', 'open', 'tree2'),
+    ])
+
+    resp = client.get('/treestatus/stack')
+    res = json.loads(resp.data)
+    res['result'][0]['trees'].sort()
+    eq_(res['result'], [{
+        'id': 1,
+        'trees': ['tree0', 'tree1'],
+        'who': 'dustin',
+        'when': '2015-07-14T00:00:00',
+        'reason': 'bug 123',
+        'status': 'closed',
+    }
+    ])
+
+    # reverts are logged, with no tags
+    assert_logged(app, 'tree1', 'closed', 'bug 123')
+    assert_logged(app, 'tree2', 'open', 'tree2')
+
+
+@test_context.specialize(db_setup=db_setup_stack, user=admin)
+def test_revert_stack_no_perms(app, client):
+    """REVERTing a stack without sheriff privs fails"""
+    resp = client.open('/treestatus/stack/2', method='REVERT')
+    eq_(resp.status_code, 403)
+
+
+@test_context.specialize(db_setup=db_setup_stack, user=sheriff)
+def test_revert_stack_nosuch(client):
+    """REVERTing /treestatus/stack/N where there's no such stack ID returns 404"""
+    resp = client.open('/treestatus/stack/99', method='REVERT')
+    eq_(resp.status_code, 404)
+
+
+@test_context.specialize(db_setup=db_setup_stack, user=sheriff)
+def test_delete_stack_change(client):
+    """DELETE'ing /treestatus/stack/N removes the change from the stack but does
+    not change the trees."""
+    resp = client.get('/treestatus/trees')
+    eq_(resp.status_code, 200)
+    trees_before = json.loads(resp.data)['result']
+
+    resp = client.open('/treestatus/stack/2', method='DELETE')
+    eq_(resp.status_code, 204)
+
+    resp = client.get('/treestatus/trees')
+    eq_(resp.status_code, 200)
+    trees_after = json.loads(resp.data)['result']
+    eq_(trees_before, trees_after)
+
+    resp = client.get('/treestatus/stack')
+    res = json.loads(resp.data)
+    res['result'][0]['trees'].sort()
+    eq_(res['result'], [{
+        'id': 1,
+        'trees': ['tree0', 'tree1'],
+        'who': 'dustin',
+        'when': '2015-07-14T00:00:00',
+        'reason': 'bug 123',
+        'status': 'closed',
+    }
+    ])
+
+
+@test_context.specialize(db_setup=db_setup_stack, user=admin)
+def test_delete_stack_no_perms(app, client):
+    """DELETE'ing a stack without sheriff privs fails"""
+    resp = client.open('/treestatus/stack/2', method='DELETE')
+    eq_(resp.status_code, 403)
+
+
+@test_context.specialize(db_setup=db_setup_stack, user=sheriff)
+def test_delete_stack_nosuch(client):
+    """DELETE'ing /treestatus/stack/N where there's no such stack ID returns 404"""
+    resp = client.open('/treestatus/stack/99', method='DELETE')
+    eq_(resp.status_code, 404)
+
+
+@test_context.specialize(db_setup=db_setup_stack, user=sheriff)
+def test_update_trees_no_remember(app, client):
+    """UPDATE'ing a tree without remembering changes updates those trees and
+    clears out the stack for those trees."""
+    update = {'trees': ['tree1'], 'status': 'open',
+              'reason': 'fire extinguished',
+              'tags': ['fire', 'water'],
+              'remember': False}
+    resp = client.open('/treestatus/trees', method='UPDATE',
+                       data=json.dumps(update),
+                       headers=[('Content-Type', 'application/json')])
+    eq_(resp.status_code, 204)
+
+    resp = client.get('/treestatus/trees')
+    eq_(resp.status_code, 200)
+    updated_status = sorted([(t['tree'], t['status'], t['reason'])
+                             for t in json.loads(resp.data)['result'].values()])
+    eq_(updated_status, [
+        ('tree0', 'closed', 'bug 123'),
+        ('tree1', 'open', 'fire extinguished'),
+        ('tree2', 'closed', 'bug 456'),
+    ])
+
+    resp = client.get('/treestatus/stack')
+    res = json.loads(resp.data)
+    eq_(res['result'], [{
+        'id': 2,
+        'trees': ['tree2'],  # tree1 removed
+        'when': '2015-07-16T00:00:00',
+        'who': 'dustin',
+        'reason': 'bug 456',
+        'status': 'closed',
+    }, {
+        'id': 1,
+        'trees': ['tree0'],  # tree1 removed
+        'who': 'dustin',
+        'when': '2015-07-14T00:00:00',
+        'reason': 'bug 123',
+        'status': 'closed',
+    }
+    ])
+
+    assert_logged(app, 'tree1', 'open', 'fire extinguished',
+                  tags=['fire', 'water'])
+
+
+@test_context.specialize(db_setup=db_setup_stack, user=admin)
+def test_update_trees_no_perms(app, client):
+    """UPDATE'ing a tree without admin perms fails"""
+    update = {'trees': ['tree1'], 'status': 'open',
+              'reason': 'fire extinguished',
+              'tags': ['fire', 'water'],
+              'remember': False}
+    resp = client.open('/treestatus/trees', method='UPDATE',
+                       data=json.dumps(update),
+                       headers=[('Content-Type', 'application/json')])
+    eq_(resp.status_code, 403)
+
+
+@test_context.specialize(db_setup=db_setup_stack, user=sheriff)
+def test_update_trees_no_remember_remove_stack_entry(app, client):
+    """UPDATE'ing a tree without remembering changes updates those trees and
+    clears out the stack for those trees.  When a stack entry has no trees,
+    it is removed."""
+    update = {'trees': ['tree1', 'tree0'], 'status': 'open',
+              'reason': 'fire extinguished',
+              'tags': [],
+              'remember': False}
+    resp = client.open('/treestatus/trees', method='UPDATE',
+                       data=json.dumps(update),
+                       headers=[('Content-Type', 'application/json')])
+    eq_(resp.status_code, 204)
+
+    resp = client.get('/treestatus/trees')
+    eq_(resp.status_code, 200)
+    updated_status = sorted([(t['tree'], t['status'], t['reason'])
+                             for t in json.loads(resp.data)['result'].values()])
+    eq_(updated_status, [
+        ('tree0', 'open', 'fire extinguished'),
+        ('tree1', 'open', 'fire extinguished'),
+        ('tree2', 'closed', 'bug 456'),
+    ])
+
+    resp = client.get('/treestatus/stack')
+    res = json.loads(resp.data)
+    eq_(res['result'], [{
+        'id': 2,
+        'trees': ['tree2'],  # tree1 removed
+        'when': '2015-07-16T00:00:00',
+        'who': 'dustin',
+        'reason': 'bug 456',
+        'status': 'closed',
+    }])  # stack entry 1 removed
+
+    assert_logged(app, 'tree0', 'open', 'fire extinguished')
+    assert_logged(app, 'tree1', 'open', 'fire extinguished')
+
+
+@test_context.specialize(db_setup=db_setup_stack, user=sheriff)
+def test_update_trees_closed_without_tags(client):
+    """UPDATE'ing trees to close them without tags is a bad request"""
+    update = {'trees': ['tree1', 'tree0'], 'status': 'closed',
+              'reason': 'bomb damage',
+              'tags': [], 'remember': True}
+    resp = client.open('/treestatus/trees', method='UPDATE',
+                       data=json.dumps(update),
+                       headers=[('Content-Type', 'application/json')])
+    eq_(resp.status_code, 400)
+
+
+@test_context.specialize(db_setup=db_setup_stack, user=sheriff)
+def test_update_trees_remember(app, client):
+    """UPDATE'ing a tree and remembering changes updates those trees and
+    adds a stack entry."""
+    update = {'trees': ['tree1', 'tree0'], 'status': 'closed',
+              'reason': 'bomb damage',
+              'tags': ['c4'], 'remember': True}
+    with set_time(datetime.datetime(2015, 7, 21, 0, 0, 0)):
+        resp = client.open('/treestatus/trees', method='UPDATE',
+                           data=json.dumps(update),
+                           headers=[('Content-Type', 'application/json')])
+    eq_(resp.status_code, 204)
+
+    resp = client.get('/treestatus/trees')
+    eq_(resp.status_code, 200)
+    updated_status = sorted([(t['tree'], t['status'], t['reason'])
+                             for t in json.loads(resp.data)['result'].values()])
+    eq_(updated_status, [
+        ('tree0', 'closed', 'bomb damage'),
+        ('tree1', 'closed', 'bomb damage'),
+        ('tree2', 'closed', 'bug 456'),
+    ])
+
+    resp = client.get('/treestatus/stack')
+    res = json.loads(resp.data)
+    for st in res['result']:
+        st['trees'].sort()
+    eq_(res['result'], [{
+        'id': 3,
+        'trees': ['tree0', 'tree1'],
+        'when': '2015-07-21T00:00:00',
+        'who': 'human:user@domain.com',
+        'reason': 'bomb damage',
+        'status': 'closed',
+    }, {
+        'id': 2,
+        'trees': ['tree1', 'tree2'],
+        'when': '2015-07-16T00:00:00',
+        'who': 'dustin',
+        'reason': 'bug 456',
+        'status': 'closed',
+    }, {
+        'id': 1,
+        'trees': ['tree0', 'tree1'],
+        'who': 'dustin',
+        'when': '2015-07-14T00:00:00',
+        'reason': 'bug 123',
+        'status': 'closed',
+    }
+    ])
+
+    assert_logged(app, 'tree0', 'closed', 'bomb damage', tags=['c4'])
+    assert_logged(app, 'tree1', 'closed', 'bomb damage', tags=['c4'])

--- a/relengapi/blueprints/treestatus/test_treestatus.py
+++ b/relengapi/blueprints/treestatus/test_treestatus.py
@@ -170,16 +170,21 @@ def test_tree_view(client):
 @test_context
 def test_get_trees(client):
     """Getting /treestatus/trees results in a dictionary of trees keyed by
-    name"""
+    name, with a no-cache header and ACAO *"""
     resp = client.get('/treestatus/trees')
     eq_(json.loads(resp.data)['result'], {'tree1': tree1_json})
+    eq_(resp.headers['Cache-Control'], 'no-cache')
+    eq_(resp.headers['Access-Control-Allow-Origin'], '*')
 
 
 @test_context
 def test_get_tree(client):
-    """Getting /treestatus/trees/tree1 results in the tree data"""
+    """Getting /treestatus/trees/tree1 results in the tree data, with a
+    no-cache header and ACAO *"""
     resp = client.get('/treestatus/trees/tree1')
     eq_(json.loads(resp.data)['result'], tree1_json)
+    eq_(resp.headers['Cache-Control'], 'no-cache')
+    eq_(resp.headers['Access-Control-Allow-Origin'], '*')
 
 
 @test_context
@@ -279,7 +284,7 @@ def test_delete_tree_nosuch(client):
 @test_context
 def test_get_logs(client):
     """Getting /treestatus/trees/tree1/logs results in a sorted list of log
-    entries (newest first)"""
+    entries (newest first), with a no-cache header and ACAO *"""
     resp = client.get('/treestatus/trees/tree1/logs')
     eq_(json.loads(resp.data)['result'], [{
         'tree': 'tree1',
@@ -304,6 +309,8 @@ def test_get_logs(client):
         'status': 'opened',
     }
     ])
+    eq_(resp.headers['Cache-Control'], 'no-cache')
+    eq_(resp.headers['Access-Control-Allow-Origin'], '*')
 
 
 @test_context

--- a/relengapi/blueprints/treestatus/test_treestatus.py
+++ b/relengapi/blueprints/treestatus/test_treestatus.py
@@ -26,7 +26,7 @@ tree1_json = {
 
 
 def db_setup(app):
-    session = app.db.session('treestatus')
+    session = app.db.session('relengapi')
     tree = model.DbTree(
         tree=tree1_json['tree'],
         status=tree1_json['status'],
@@ -56,7 +56,7 @@ def db_setup(app):
 
 def db_setup_stack(app):
     for tn in range(3):
-        session = app.db.session('treestatus')
+        session = app.db.session('relengapi')
         tree = model.DbTree(
             tree='tree%d' % tn,
             status='closed',
@@ -100,7 +100,7 @@ sheriff = userperms([p.treestatus.sheriff])
 
 config = {'TREESTATUS_CACHE': 'mock://ts'}
 
-test_context = TestContext(databases=['treestatus'],
+test_context = TestContext(databases=['relengapi'],
                            db_setup=db_setup,
                            config=config)
 
@@ -115,7 +115,7 @@ def set_time(now):
 def assert_logged(app, tree, status, reason, when=None,
                   who='human:user@domain.com', tags=[]):
     with app.app_context():
-        session = app.db.session('treestatus')
+        session = app.db.session('relengapi')
         q = session.query(model.DbLog)
         q = q.filter_by(tree=tree)
         q = q.order_by(model.DbLog.when)
@@ -138,7 +138,7 @@ def assert_logged(app, tree, status, reason, when=None,
 
 def assert_nothing_logged(app, tree):
     with app.app_context():
-        session = app.db.session('treestatus')
+        session = app.db.session('relengapi')
         q = session.query(model.DbLog)
         q = q.filter_by(tree=tree)
         q = q.order_by(model.DbLog.when)
@@ -288,7 +288,7 @@ def test_delete_tree(app, client):
     """Deleting a tree deletes the tree and any associated logs
     and changes"""
     with app.app_context():
-        session = app.db.session('treestatus')
+        session = app.db.session('relengapi')
         l = model.DbLog(
             tree='tree1',
             when=datetime.datetime(2015, 6, 15, 17, 44, 00),
@@ -362,7 +362,7 @@ def test_get_logs_all(client, app):
     """Getting /treestatus/trees/tree1/logs with over 5 logs present
     results in only 5 logs, unless given ?all=1"""
     # add the log entries
-    session = app.db.session('treestatus')
+    session = app.db.session('relengapi')
     for ln in range(5):
         l = model.DbLog(
             tree='tree1',

--- a/relengapi/blueprints/treestatus/types.py
+++ b/relengapi/blueprints/treestatus/types.py
@@ -44,8 +44,8 @@ class JsonTreeLog(wsme.types.Base):
     #: the user making the change
     who = wsme.types.wsattr(unicode, mandatory=True)
 
-    #: the action (the new status)
-    action = wsme.types.wsattr(unicode, mandatory=True)
+    #: the new status
+    status = wsme.types.wsattr(unicode, mandatory=True)
 
     #: the reason for the status
     reason = wsme.types.wsattr(unicode, mandatory=True)

--- a/relengapi/blueprints/treestatus/types.py
+++ b/relengapi/blueprints/treestatus/types.py
@@ -1,0 +1,106 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import wsme.types
+
+from datetime import datetime
+
+
+class JsonTree(wsme.types.Base):
+
+    """A representation of a single tree.
+    """
+
+    _name = 'Tree'
+
+    #: the name of the tree
+    tree = wsme.types.wsattr(unicode, mandatory=True)
+
+    #: the current status
+    status = wsme.types.wsattr(unicode, mandatory=True)
+
+    #: the reason for the status
+    reason = wsme.types.wsattr(unicode, mandatory=True)
+
+    #: even more information about the status
+    message_of_the_day = wsme.types.wsattr(unicode, mandatory=True)
+
+
+class JsonTreeLog(wsme.types.Base):
+
+    """ A recorded change to a tree's status or reason, along with a set of
+    tags assigned at the time.  This is useful for analysis of tree closures
+    and their causes.  """
+
+    _name = 'TreeLog'
+
+    #: the name of the tree
+    tree = wsme.types.wsattr(unicode, mandatory=True)
+
+    #: the time the change occurred
+    when = wsme.types.wsattr(datetime, mandatory=True)
+
+    #: the user making the change
+    who = wsme.types.wsattr(unicode, mandatory=True)
+
+    #: the action (the new status)
+    action = wsme.types.wsattr(unicode, mandatory=True)
+
+    #: the reason for the status
+    reason = wsme.types.wsattr(unicode, mandatory=True)
+
+    #: tags for the change
+    tags = wsme.types.wsattr([unicode], mandatory=True)
+
+
+class JsonStateChange(wsme.types.Base):
+
+    """A change to one or more trees' status, suitable for reverting the
+    change.  Some of the information here is redundant to TreeLog, but is
+    present to help users determine which change to revert.  The previous state
+    of the tree is not exposed in this data type.  """
+
+    _name = 'TreeStateChange'
+
+    #: id of this change
+    id = wsme.types.wsattr(int, mandatory=True)
+
+    #: the names of the affected trees
+    trees = wsme.types.wsattr([unicode], mandatory=True)
+
+    #: the time the change occurred
+    when = wsme.types.wsattr(datetime, mandatory=True)
+
+    #: the user who made the change
+    who = wsme.types.wsattr(unicode, mandatory=True)
+
+    #: the updated (new) status
+    status = wsme.types.wsattr(unicode, mandatory=True)
+
+    #: the reason for the status change
+    reason = wsme.types.wsattr(unicode, mandatory=True)
+
+
+class JsonTreeUpdate(wsme.types.Base):
+
+    """A requested update to one or more trees.  See the corresponding method
+    for information on which fields must be supplied and when.  """
+
+    _name = 'TreeUpdate'
+
+    #: the trees to update
+    trees = wsme.types.wsattr([unicode], mandatory=True)
+
+    #: the new tree status (for all affected trees)
+    status = wsme.types.wsattr(unicode, mandatory=True)
+
+    #: the reason for the status
+    reason = wsme.types.wsattr(unicode, mandatory=True)
+
+    #: tags associated with the status update
+    tags = wsme.types.wsattr([unicode], mandatory=True)
+
+    #: if true, add this change to the undo stack; if false,
+    #: remove the affected trees from the undo stack.
+    remember = wsme.types.wsattr(bool, mandatory=True)

--- a/relengapi/blueprints/treestatus/types.py
+++ b/relengapi/blueprints/treestatus/types.py
@@ -93,14 +93,19 @@ class JsonTreeUpdate(wsme.types.Base):
     trees = wsme.types.wsattr([unicode], mandatory=True)
 
     #: the new tree status (for all affected trees)
-    status = wsme.types.wsattr(unicode, mandatory=True)
+    status = wsme.types.wsattr(unicode)
 
     #: the reason for the status
-    reason = wsme.types.wsattr(unicode, mandatory=True)
+    reason = wsme.types.wsattr(unicode)
 
-    #: tags associated with the status update
-    tags = wsme.types.wsattr([unicode], mandatory=True)
+    #: the message of the day for the tree
+    message_of_the_day = wsme.types.wsattr(unicode)
 
-    #: if true, add this change to the undo stack; if false,
-    #: remove the affected trees from the undo stack.
-    remember = wsme.types.wsattr(bool, mandatory=True)
+    #: tags associated with the status update; this is required (including at
+    #: least one tag) if status = 'closed',
+
+    tags = wsme.types.wsattr([unicode])
+
+    #: if true, add the change to the status and reason to the undo stack.
+    #: Note that updates to the message of the day are not recorded.
+    remember = wsme.types.wsattr(bool)

--- a/relengapi/docs/usage/index.rst
+++ b/relengapi/docs/usage/index.rst
@@ -17,3 +17,4 @@ Subsequent sections describe the interfaces provided by the individual component
     tooltool
     slaveloan
     archiver
+    treestatus

--- a/relengapi/docs/usage/treestatus.rst
+++ b/relengapi/docs/usage/treestatus.rst
@@ -1,0 +1,32 @@
+TreeStatus
+==========
+
+TreeStatus is a relatively simple tool to keep track of the status of the "trees" at Mozilla.
+A "tree" is a version-control repository, and can generally be in one of three states: open, closed, or approval-required.
+These states affect the ability of developers to push new commits to these repositories.
+Trees typically close when something prevents builds and tests from succeeding.
+
+The tree status tool provides an interface for anyone to see the current status of all trees.
+It also allows "sheriffs" to manipulate tree status.
+
+In addition to tracking the current state, the tool provides a log of changes to tree states
+It also provides a "stack" of remembered previous states, to make it easy to re-open after a failure condition is resolved.
+
+.. note::
+
+
+    Changes to a tree's message of the day are not logged, nor stored in the stack.
+
+Types
+-----
+
+.. api:autotype::
+    Tree
+    TreeLog
+    TreeStateChange
+    TreeUpdate
+
+Endpoints
+---------
+
+.. api:autoendpoint:: treestatus.*


### PR DESCRIPTION
This makes some pretty substantial changes to the sheriff/admin UIs, but is largely the same for users.

Functionally, a big difference here is that trees are no longer removed from outstanding changes if an update is made with the "remember" checkbox unchecked.  That allows the common workflow of closing trees with reason "OMG!", then later following up with a new reason ("bug 1234") without remembering the latter change.  When the first change is undone, the status returns to what it was before.

The DB changes quite a bit, too -- new table names, column names, and column types.  Transitioning from one to the other shouldn't be too hard, though - a decent mysqldump should do the trick.  We'll also need to change the hghook to point at a different URL.  I had a look at the hook already, and it's an easy fix -- just needs to be landed.  During the few minutes of transition, we'd just need to update tree statuses in two places.