### PR TITLE
fixes typo where task id was referenced before use

### DIFF
--- a/relengapi/blueprints/archiver/__init__.py
+++ b/relengapi/blueprints/archiver/__init__.py
@@ -196,7 +196,7 @@ def get_archive(src_url, key, preferred_region):
                 session.commit()
             else:
                 return {}, 500
-        return {}, 202, {'Location': url_for('archiver.task_status', task_id=task.id)}
+        return {}, 202, {'Location': url_for('archiver.task_status', task_id=task_id)}
 
     log.info("generating GET URL to {}, expires in {}s".format(key, GET_EXPIRES_IN))
     # return 302 pointing to s3 url with archive


### PR DESCRIPTION
I can't use task now that we moved it outside the block it was created. we know what the task id is though as we define it in task_id already