### PR TITLE
Set `CELERY_ACCEPT_CONTENT` if it's not already set

### DIFF
--- a/relengapi/lib/celery.py
+++ b/relengapi/lib/celery.py
@@ -21,6 +21,13 @@ logger = structlog.get_logger()
 
 
 def make_celery(app):
+    # default to using JSON, rather than Pickle (Celery's default, but Celery
+    # warns about it)
+    for var, dfl in [
+            ('CELERY_ACCEPT_CONTENT', ['json']),
+            ('CELERY_TASK_SERIALIZER', 'json'),
+            ('CELERY_RESULT_SERIALIZER', 'json')]:
+        app.config[var] = app.config.get(var, dfl)
     broker = app.config.get('CELERY_BROKER_URL', 'memory://')
     celery = Celery(app.import_name, broker=broker)
     celery.conf.update(app.config)


### PR DESCRIPTION
This warning is kind of silly -- if you're exposing your celery queue to malicious data, you're already doing it wrong, pickle or not.  So we should silence this in code by setting `CELERY_ACCEPT_CONTENT` if it's not already set.

```
[2015-06-18 10:36:30,016: WARNING/MainProcess] /data/www/relengapi/virtualenv/lib/python2.7/site-packages/celery/apps/worker.py:161: CDeprecationWarning: 
Starting from version 3.2 Celery will refuse to accept pickle by default.

The pickle serializer is a security concern as it may give attackers
the ability to execute any command.  It's important to secure
your broker from unauthorized access when using pickle, so we think
that enabling pickle should require a deliberate action and not be
the default choice.

If you depend on pickle then you should set a setting to disable this
warning and to be sure that everything will continue working
when you upgrade to Celery 3.2::

    CELERY_ACCEPT_CONTENT = ['pickle', 'json', 'msgpack', 'yaml']

You must only enable the serializers that you will actually use.


  warnings.warn(CDeprecationWarning(W_PICKLE_DEPRECATED))
```