### PR TITLE
Make `relengapi.apimethod`, etc. exist when importing `relengapi`

### DIFF
--- a/relengapi/app.py
+++ b/relengapi/app.py
@@ -4,7 +4,6 @@
 
 import os
 import pkg_resources
-import relengapi
 import structlog
 import uuid
 import wsme.types
@@ -24,12 +23,6 @@ from relengapi.lib import layout
 from relengapi.lib import logging as relengapi_logging
 from relengapi.lib import memcached
 from relengapi.lib import monkeypatches
-from relengapi.lib import permissions
-
-# set up the 'relengapi' namespace; it's a namespaced module, so no code
-# is allowed in __init__.py
-relengapi.p = permissions.p
-relengapi.apimethod = api.apimethod
 
 # apply monkey patches
 monkeypatches.monkeypatch()

--- a/relengapi/blueprints/badpenny/__init__.py
+++ b/relengapi/blueprints/badpenny/__init__.py
@@ -7,8 +7,6 @@ import structlog
 from flask import Blueprint
 from flask import current_app
 from flask import url_for
-from relengapi import apimethod
-from relengapi import p
 from relengapi.blueprints.badpenny import cleanup
 from relengapi.blueprints.badpenny import cron
 from relengapi.blueprints.badpenny import execution
@@ -18,6 +16,8 @@ from relengapi.lib import angular
 from relengapi.lib import api
 from relengapi.lib import permissions
 from relengapi.lib import time
+from relengapi.lib.api import apimethod
+from relengapi.lib.permissions import p
 from werkzeug.exceptions import NotFound
 
 logger = structlog.get_logger()

--- a/relengapi/blueprints/clobberer/__init__.py
+++ b/relengapi/blueprints/clobberer/__init__.py
@@ -26,10 +26,10 @@ from models import Build
 from models import ClobberTime
 from models import DB_DECLARATIVE_BASE
 
-from relengapi import apimethod
-from relengapi import p
 from relengapi.lib import angular
 from relengapi.lib import api
+from relengapi.lib.api import apimethod
+from relengapi.lib.permissions import p
 
 logger = structlog.get_logger()
 

--- a/relengapi/blueprints/clobberer/test_api.py
+++ b/relengapi/blueprints/clobberer/test_api.py
@@ -9,8 +9,8 @@ from copy import deepcopy
 from nose.tools import assert_greater
 from nose.tools import eq_
 
-from relengapi import p
 from relengapi.lib import auth
+from relengapi.lib.permissions import p
 from relengapi.lib.testing.context import TestContext
 
 from . import BUILDDIR_REL_PREFIX

--- a/relengapi/blueprints/mapper/__init__.py
+++ b/relengapi/blueprints/mapper/__init__.py
@@ -20,7 +20,7 @@ from sqlalchemy import orm
 from sqlalchemy.orm.exc import MultipleResultsFound
 from sqlalchemy.orm.exc import NoResultFound
 
-from relengapi import p
+from relengapi.lib.permissions import p
 
 logger = structlog.get_logger()
 # logging.basicConfig(level=logging.DEBUG)

--- a/relengapi/blueprints/mapper/test_mapper.py
+++ b/relengapi/blueprints/mapper/test_mapper.py
@@ -6,10 +6,10 @@ import json
 import mock
 
 from nose.tools import eq_
-from relengapi import p
 from relengapi.blueprints.mapper import Hash
 from relengapi.blueprints.mapper import Project
 from relengapi.lib import auth
+from relengapi.lib.permissions import p
 from relengapi.lib.testing.context import TestContext
 from sqlalchemy.orm.exc import MultipleResultsFound
 from sqlalchemy.orm.exc import NoResultFound

--- a/relengapi/blueprints/slaveloan/__init__.py
+++ b/relengapi/blueprints/slaveloan/__init__.py
@@ -13,13 +13,13 @@ from flask import g
 from flask import render_template
 from flask import url_for
 from flask.ext.login import current_user
-from relengapi import apimethod
-from relengapi import p
 from relengapi.blueprints.slaveloan import task_groups
 from relengapi.blueprints.slaveloan.slave_mappings import slave_patterns
 from relengapi.blueprints.slaveloan.slave_mappings import slave_to_slavetype
 from relengapi.lib import angular
 from relengapi.lib import api
+from relengapi.lib.api import apimethod
+from relengapi.lib.permissions import p
 from relengapi.util import tz
 from werkzeug.exceptions import BadRequest
 from werkzeug.exceptions import InternalServerError

--- a/relengapi/blueprints/tokenauth/__init__.py
+++ b/relengapi/blueprints/tokenauth/__init__.py
@@ -14,8 +14,6 @@ from flask import g
 from flask import url_for
 from flask.ext.login import current_user
 from flask.ext.login import login_required
-from relengapi import apimethod
-from relengapi import p
 from relengapi.blueprints.tokenauth import loader
 from relengapi.blueprints.tokenauth import tables
 from relengapi.blueprints.tokenauth import tokenstr
@@ -23,6 +21,8 @@ from relengapi.blueprints.tokenauth import types
 from relengapi.blueprints.tokenauth import usermonitor
 from relengapi.lib import angular
 from relengapi.lib import api
+from relengapi.lib.api import apimethod
+from relengapi.lib.permissions import p
 from relengapi.util import tz
 from werkzeug.exceptions import BadRequest
 from werkzeug.exceptions import Forbidden

--- a/relengapi/blueprints/tokenauth/loader.py
+++ b/relengapi/blueprints/tokenauth/loader.py
@@ -5,10 +5,10 @@
 import structlog
 import time
 
-from relengapi import p
 from relengapi.blueprints.tokenauth import tables
 from relengapi.blueprints.tokenauth import tokenstr
 from relengapi.lib import auth
+from relengapi.lib.permissions import p
 from werkzeug.exceptions import BadRequest
 
 logger = structlog.get_logger()

--- a/relengapi/blueprints/tokenauth/tables.py
+++ b/relengapi/blueprints/tokenauth/tables.py
@@ -4,9 +4,9 @@
 
 import sqlalchemy as sa
 
-from relengapi import p
 from relengapi.blueprints.tokenauth import types
 from relengapi.lib import db
+from relengapi.lib.permissions import p
 
 
 class Token(db.declarative_base('relengapi')):

--- a/relengapi/blueprints/tokenauth/test_loader.py
+++ b/relengapi/blueprints/tokenauth/test_loader.py
@@ -6,13 +6,13 @@ import mock
 
 from flask import json
 from nose.tools import eq_
-from relengapi import p
 from relengapi.blueprints.tokenauth import loader
 from relengapi.blueprints.tokenauth import tables
 from relengapi.blueprints.tokenauth.test_tokenauth import test_context
 from relengapi.blueprints.tokenauth.util import FakeSerializer
 from relengapi.blueprints.tokenauth.util import insert_prm
 from relengapi.blueprints.tokenauth.util import insert_usr
+from relengapi.lib.permissions import p
 
 
 def test_TokenUser_str_tmp():

--- a/relengapi/blueprints/tokenauth/test_tokenauth.py
+++ b/relengapi/blueprints/tokenauth/test_tokenauth.py
@@ -11,7 +11,6 @@ from datetime import datetime
 from flask import json
 from flask.ext.login import current_user
 from nose.tools import eq_
-from relengapi import p
 from relengapi.blueprints.tokenauth import types
 from relengapi.blueprints.tokenauth.tables import Token
 from relengapi.blueprints.tokenauth.util import FakeSerializer
@@ -21,6 +20,7 @@ from relengapi.blueprints.tokenauth.util import insert_usr
 from relengapi.blueprints.tokenauth.util import prm_json
 from relengapi.blueprints.tokenauth.util import usr_json
 from relengapi.lib import auth
+from relengapi.lib.permissions import p
 from relengapi.lib.testing.context import TestContext
 from wsme.rest.json import fromjson
 from wsme.rest.json import tojson

--- a/relengapi/blueprints/tokenauth/test_usermonitor.py
+++ b/relengapi/blueprints/tokenauth/test_usermonitor.py
@@ -6,10 +6,10 @@ import contextlib
 import mock
 
 from nose.tools import eq_
-from relengapi import p
 from relengapi.blueprints.tokenauth import tables
 from relengapi.blueprints.tokenauth import usermonitor
 from relengapi.blueprints.tokenauth.util import insert_usr
+from relengapi.lib.permissions import p
 from relengapi.lib.testing.context import TestContext
 
 p.test_usermonitor.a.doc("A")

--- a/relengapi/blueprints/tokenauth/util.py
+++ b/relengapi/blueprints/tokenauth/util.py
@@ -5,8 +5,8 @@
 import json
 
 from itsdangerous import BadData
-from relengapi import p
 from relengapi.blueprints.tokenauth.tables import Token
+from relengapi.lib.permissions import p
 
 # test utilities
 

--- a/relengapi/blueprints/treestatus/__init__.py
+++ b/relengapi/blueprints/treestatus/__init__.py
@@ -11,18 +11,18 @@ from flask import Blueprint
 from flask import current_app
 from flask import url_for
 from flask.ext.login import current_user
-from relengapi import apimethod
 from relengapi.lib import angular
 from relengapi.lib import api
 from relengapi.lib import http
 from relengapi.lib import time as relengapi_time
+from relengapi.lib.api import apimethod
 from werkzeug.exceptions import BadRequest
 from werkzeug.exceptions import NotFound
 from wsme import Unset
 
-from relengapi import p
 from relengapi.blueprints.treestatus import model
 from relengapi.blueprints.treestatus import types
+from relengapi.lib.permissions import p
 
 bp = Blueprint('treestatus', __name__,
                static_folder='static',

--- a/relengapi/blueprints/treestatus/test_treestatus.py
+++ b/relengapi/blueprints/treestatus/test_treestatus.py
@@ -9,11 +9,11 @@ import pprint
 from contextlib import contextmanager
 from flask import json
 from nose.tools import eq_
-from relengapi import p
 from relengapi.blueprints import treestatus
 from relengapi.blueprints.treestatus import model
 from relengapi.blueprints.treestatus import types
 from relengapi.lib import auth
+from relengapi.lib.permissions import p
 from relengapi.lib.testing.context import TestContext
 
 

--- a/relengapi/docs/development/api_methods.rst
+++ b/relengapi/docs/development/api_methods.rst
@@ -81,7 +81,7 @@ Decorator
 
 All API view methods should be wrapped with :py:func:`~relengapi.lib.api.apimethod`, which is available in the ``relengapi`` namespace::
 
-    from relengapi import apimethod
+    from relengapi.lib.api import apimethod
     ...
     @bp.route('/widget/<int:widget_id>')
     @apimethod(Widget, int)

--- a/relengapi/docs/development/auth.rst
+++ b/relengapi/docs/development/auth.rst
@@ -113,7 +113,7 @@ Accessing Permissions
 
 A bit of syntactic sugar makes it very easy to access permissions ::
 
-    from relengapi import p
+    from relengapi.lib.permissions import p
     r = p.tasks.view
 
 The ``permissions`` object generates permissions through attribute access, so the example above creates the ``tasks.view`` permission.
@@ -123,7 +123,7 @@ Adding Permissions
 
 To add a new permission, simply access it and document it with the  :py:meth:`~relengapi.lib.permissions.Permission.doc` method::
 
-    from relengapi import p
+    from relengapi.lib.permissions import p
     p.tasks.view.doc("View tasks")
 
 Verifying a Permission

--- a/relengapi/docs/development/blueprints.rst
+++ b/relengapi/docs/development/blueprints.rst
@@ -27,7 +27,7 @@ Within ``__init__.py``, create a new blueprint::
     import structlog
 
     from flask import Blueprint
-    from relengapi import apimethod
+    from relengapi.lib.api import apimethod
 
     logger = structlog.get_logger()
     bp = Blueprint('bubbler', __name__,

--- a/relengapi/lib/angular.py
+++ b/relengapi/lib/angular.py
@@ -9,8 +9,8 @@ from flask import render_template
 from flask import request
 from flask import url_for
 from flask.ext.login import current_user
-from relengapi import p
 from relengapi.lib import permissions
+from relengapi.lib.permissions import p
 
 
 def template(template_name, *dependency_urls, **initial_data):

--- a/relengapi/lib/auth/perms_types/ldap_groups.py
+++ b/relengapi/lib/auth/perms_types/ldap_groups.py
@@ -6,9 +6,9 @@ import itertools
 import ldap
 import structlog
 
-from relengapi import p
 from relengapi.lib.auth import base
 from relengapi.lib.auth import permissions_stale
+from relengapi.lib.permissions import p
 
 
 class LdapGroupsAuthz(base.BaseAuthz):

--- a/relengapi/lib/auth/perms_types/static.py
+++ b/relengapi/lib/auth/perms_types/static.py
@@ -5,9 +5,9 @@
 import itertools
 
 from functools import partial
-from relengapi import p
 from relengapi.lib.auth import base
 from relengapi.lib.auth import permissions_stale
+from relengapi.lib.permissions import p
 
 
 class StaticAuthz(base.BaseAuthz):

--- a/relengapi/tests/test_lib_auth.py
+++ b/relengapi/tests/test_lib_auth.py
@@ -8,8 +8,8 @@ from flask.ext.login import current_user
 from nose.tools import assert_raises
 from nose.tools import eq_
 from nose.tools import with_setup
-from relengapi import p
 from relengapi.lib import auth
+from relengapi.lib.permissions import p
 from relengapi.lib.testing.context import TestContext
 
 

--- a/relengapi/tests/test_lib_auth_perms_types_ldap_groups.py
+++ b/relengapi/tests/test_lib_auth_perms_types_ldap_groups.py
@@ -11,9 +11,9 @@ import unittest
 
 from nose.tools import assert_raises
 from nose.tools import eq_
-from relengapi import p
 from relengapi.lib import auth
 from relengapi.lib.auth.perms_types import ldap_groups
+from relengapi.lib.permissions import p
 from relengapi.lib.testing.context import TestContext
 
 p.test_lga.foo.doc("Foo")

--- a/relengapi/tests/test_lib_auth_perms_types_static.py
+++ b/relengapi/tests/test_lib_auth_perms_types_static.py
@@ -6,9 +6,9 @@ import relengapi.app
 
 from nose.tools import assert_raises
 from nose.tools import eq_
-from relengapi import p
 from relengapi.lib import auth
 from relengapi.lib.auth.perms_types import static
+from relengapi.lib.permissions import p
 
 p.test_static.foo.doc("Foo")
 p.test_static.bar.doc("Bar")


### PR DESCRIPTION
`relengapi` used to be a namespace package, which meant it couldn't have attributes at import time, and they were added only later when `relengapi.app` was imported.

It's no longer a namespace package, so this is no longer required.