### PR TITLE
Add compat endpoints for compatibility with old treestatus

### DIFF
--- a/relengapi/blueprints/treestatus/__init__.py
+++ b/relengapi/blueprints/treestatus/__init__.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import flask
 import json
 import logging
 import sqlalchemy as sa
@@ -133,6 +134,19 @@ def get_trees():
     return trees
 
 
+@bp.route('/compat/trees/')
+@public_data
+def compat_get_trees():
+    """
+    Get the status of all trees in a format compatible with the old
+    treestatus
+    """
+    trees = api.get_data(get_trees)
+    resp = flask.Response(api.dumps({unicode: types.JsonTree}, trees))
+    resp.headers['content-type'] = 'application/json'
+    return resp
+
+
 @bp.route('/trees/<path:tree>')
 @public_data
 @apimethod(types.JsonTree, unicode)
@@ -152,6 +166,19 @@ def get_tree(tree):
     j = t.to_json()
     tree_cache_set(tree, j)
     return j
+
+
+@bp.route('/compat/trees/<path:tree>')
+@public_data
+def compat_get_tree(tree):
+    """
+    Get the status of a single tree in a format compatible with the old
+    treestatus
+    """
+    tree = api.get_data(get_tree, tree)
+    resp = flask.Response(api.dumps(types.JsonTree, tree))
+    resp.headers['content-type'] = 'application/json'
+    return resp
 
 
 @bp.route('/trees/<path:tree_name>', methods=['PUT'])

--- a/relengapi/blueprints/treestatus/__init__.py
+++ b/relengapi/blueprints/treestatus/__init__.py
@@ -134,9 +134,10 @@ def get_trees():
     return trees
 
 
-@bp.route('/compat/trees/')
+@bp.route('/v0/trees')
+@bp.route('/v0/trees/')
 @public_data
-def compat_get_trees():
+def v0_get_trees():
     """
     Get the status of all trees in a format compatible with the old
     treestatus
@@ -168,9 +169,9 @@ def get_tree(tree):
     return j
 
 
-@bp.route('/compat/trees/<path:tree>')
+@bp.route('/v0/trees/<path:tree>')
 @public_data
-def compat_get_tree(tree):
+def v0_get_tree(tree):
     """
     Get the status of a single tree in a format compatible with the old
     treestatus

--- a/relengapi/blueprints/treestatus/test_treestatus.py
+++ b/relengapi/blueprints/treestatus/test_treestatus.py
@@ -210,6 +210,30 @@ def test_get_trees(client):
 
 
 @test_context
+def test_compat_get_trees(client):
+    """Getting /treestatus/compat/trees/ results in a dictionary of trees keyed
+    by name, without the usual `result` wrapper, with content-type
+    application/json, and with a no-cache header and ACAO *"""
+    resp = client.get('/treestatus/compat/trees/')
+    eq_(json.loads(resp.data), {'tree1': tree1_json})
+    eq_(resp.headers['Content-Type'], 'application/json')
+    eq_(resp.headers['Cache-Control'], 'no-cache')
+    eq_(resp.headers['Access-Control-Allow-Origin'], '*')
+
+
+@test_context
+def test_compat_get_tree(client):
+    """Getting /treestatus/compat/tree/ results in a single tree, without the
+    usual `result` wrapper, with content-type application/json, and with a
+    no-cache header and ACAO *"""
+    resp = client.get('/treestatus/compat/trees/tree1')
+    eq_(json.loads(resp.data), tree1_json)
+    eq_(resp.headers['Content-Type'], 'application/json')
+    eq_(resp.headers['Cache-Control'], 'no-cache')
+    eq_(resp.headers['Access-Control-Allow-Origin'], '*')
+
+
+@test_context
 def test_get_tree(client):
     """Getting /treestatus/trees/tree1 results in the tree data, with a
     no-cache header and ACAO *"""

--- a/relengapi/blueprints/treestatus/test_treestatus.py
+++ b/relengapi/blueprints/treestatus/test_treestatus.py
@@ -210,11 +210,11 @@ def test_get_trees(client):
 
 
 @test_context
-def test_compat_get_trees(client):
-    """Getting /treestatus/compat/trees/ results in a dictionary of trees keyed
+def test_v0_get_trees(client):
+    """Getting /treestatus/v0/trees/ results in a dictionary of trees keyed
     by name, without the usual `result` wrapper, with content-type
     application/json, and with a no-cache header and ACAO *"""
-    resp = client.get('/treestatus/compat/trees/')
+    resp = client.get('/treestatus/v0/trees/')
     eq_(json.loads(resp.data), {'tree1': tree1_json})
     eq_(resp.headers['Content-Type'], 'application/json')
     eq_(resp.headers['Cache-Control'], 'no-cache')
@@ -222,11 +222,21 @@ def test_compat_get_trees(client):
 
 
 @test_context
-def test_compat_get_tree(client):
-    """Getting /treestatus/compat/tree/ results in a single tree, without the
+def test_v0_get_trees_no_slash(client):
+    """Getting /treestatus/v0/trees is the same as /v0/trees/"""
+    resp = client.get('/treestatus/v0/trees/')
+    eq_(json.loads(resp.data), {'tree1': tree1_json})
+    eq_(resp.headers['Content-Type'], 'application/json')
+    eq_(resp.headers['Cache-Control'], 'no-cache')
+    eq_(resp.headers['Access-Control-Allow-Origin'], '*')
+
+
+@test_context
+def test_v0_get_tree(client):
+    """Getting /treestatus/v0/tree/ results in a single tree, without the
     usual `result` wrapper, with content-type application/json, and with a
     no-cache header and ACAO *"""
-    resp = client.get('/treestatus/compat/trees/tree1')
+    resp = client.get('/treestatus/v0/trees/tree1')
     eq_(json.loads(resp.data), tree1_json)
     eq_(resp.headers['Content-Type'], 'application/json')
     eq_(resp.headers['Cache-Control'], 'no-cache')

--- a/relengapi/docs/usage/treestatus.rst
+++ b/relengapi/docs/usage/treestatus.rst
@@ -30,3 +30,9 @@ Endpoints
 ---------
 
 .. api:autoendpoint:: treestatus.*
+
+Compatibility Endpoints
+.......................
+
+The paths ``/treestatus/compat/trees/`` and ``/treestatus/compat/trees/<tree>`` provide the same data as ``/treestatus/trees`` and ``/treestatus/trees/<tree>``, but without the ``result`` wrapper object.
+These paths provide support for the API calls used against https://treestatus.mozilla.org.

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "wrapt",
         "blinker",  # required to use flask signals
         "pytz",
-        "wsme",
+        "wsme<0.8",  # see https://github.com/mozilla/build-relengapi/issues/325
         "croniter",
         "python-dateutil",
         "simplejson",


### PR DESCRIPTION
This is part of the deployment strategy: proxy requests from the old treestatus URL to the new.  But RelengAPI wraps every API response in {'result': ..}, while the old treestatus did not.