### PR TITLE
Make the tree log time a little easier to read

### DIFF
--- a/relengapi/blueprints/treestatus/static/tree.html
+++ b/relengapi/blueprints/treestatus/static/tree.html
@@ -23,7 +23,7 @@
                 <thead>
                     <tr>
                         <th class="tableWho">User</th>
-                        <th class="tableWhen">Time</th>
+                        <th class="tableWhen">Time (UTC)</th>
                         <th class="tableState">Action</th>
                         <th class="tableReason">Reason</th>
                         <th class="tableTags">Tags</th>
@@ -32,7 +32,7 @@
                 <tbody>
                 <tr ng-repeat="log in logs">
                     <td class="tableWho">{{log.who|shortName}}</td>
-                    <td class="tableWhen">{{log.when}} UTC</td>
+                    <td class="tableWhen">{{log.when}}</td>
                     <td class="tableState {{log.status|status2class}}">
                         {{log.status|uppercase}}
                     </td>

--- a/relengapi/blueprints/treestatus/static/treestatus.css
+++ b/relengapi/blueprints/treestatus/static/treestatus.css
@@ -73,6 +73,12 @@ h1.treestatus {
     text-decoration: none;
 }
 
+.tableWhen {
+    /* this column can get a little tight, so encourage some breathing room */
+    padding-right: 0.5em;
+    padding-left: 0.5em;
+}
+
 .tableCheck {
     min-width: 20px;
 }


### PR DESCRIPTION
Not sure why I didn't notice this before, but the table cell was running
into its neighbors, making it difficult to read.  This adds a little
more breathing room, and moves the timezone (UTC) up to the header so
it's not repeated on every line.