### PR TITLE
Use a null StorageBackend to avoid SQLite errors

### DIFF
--- a/relengapi/blueprints/docs/__init__.py
+++ b/relengapi/blueprints/docs/__init__.py
@@ -16,12 +16,31 @@ from flask import send_from_directory
 from relengapi.lib import subcommands
 from sphinx.websupport import WebSupport
 from sphinx.websupport.errors import DocumentNotFoundError
+from sphinx.websupport.storage import StorageBackend
 
 logger = structlog.get_logger()
 
 bp = Blueprint('docs', __name__,
                template_folder='templates')
 bp.root_widget_template('docs_root_widget.html', priority=100)
+
+
+class NullStorageBackend(StorageBackend):
+
+    # We don't want any storage backend for the docs -- we don't allow
+    # comments, votes, etc.
+    #
+    # Most methods are either null in the parent class, or aren't called at
+    # all; these few appear to be called, and so must be overridden
+
+    def get_metadata(self, *args, **kwargs):
+        return
+
+    def has_node(self, *args, **kwargs):
+        return False
+
+    def add_node(self, *args, **kwargs):
+        return False
 
 
 def get_builddir():
@@ -48,6 +67,7 @@ def get_support(force=False, quiet=False):
             builddir=builddir,
             staticroot='/docs/static',
             docroot='/docs',
+            storage=NullStorageBackend(),
             **kwargs)
     return current_app.docs_websupport
 


### PR DESCRIPTION
This avoids
```
[Tue Sep 01 21:47:02 2015] [error] 2015-09-01 21:47:02,510 [sqlalchemy.pool.NullPool] Exception during reset or similar
[Tue Sep 01 21:47:02 2015] [error] Traceback (most recent call last):
[Tue Sep 01 21:47:02 2015] [error]   File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/sqlalchemy/pool.py", line 631, in _finalize_fairy
[Tue Sep 01 21:47:02 2015] [error]     fairy._reset(pool)
[Tue Sep 01 21:47:02 2015] [error]   File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/sqlalchemy/pool.py", line 765, in _reset
[Tue Sep 01 21:47:02 2015] [error]     pool._dialect.do_rollback(self)
[Tue Sep 01 21:47:02 2015] [error]   File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/sqlalchemy/engine/default.py", line 412, in do_rollback
[Tue Sep 01 21:47:02 2015] [error]     dbapi_connection.rollback()
[Tue Sep 01 21:47:02 2015] [error]   File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/newrelic-2.46.0.37/newrelic/hooks/database_dbapi2.py", line 76, in rollback
[Tue Sep 01 21:47:02 2015] [error]     return self.__wrapped__.rollback()
[Tue Sep 01 21:47:02 2015] [error] ProgrammingError: SQLite objects created in a thread can only be used in that same thread.The object was created in thread id 140357840086784 and this is thread id 140357585073920
```
by just not using sqlite at all