### PR TITLE
Use real HTTP verbs in treestatus

### DIFF
--- a/relengapi/blueprints/treestatus/__init__.py
+++ b/relengapi/blueprints/treestatus/__init__.py
@@ -257,20 +257,20 @@ def get_stack():
 
 @bp.route('/stack/<int:id>', methods=['DELETE'])
 @p.treestatus.sheriff.require()
-@apimethod(None, int)
+@apimethod(None, int, int)
 def revert_change(id, revert=None):
     """
     Remove the given change from the undo stack.
 
     With ``?revert=1`` This applies the settings that were
     present before the change to the affected trees.
-    
+
     With ``?revert=0`` or omitting the revert keyword, it merely removes
     the change from the stack without changing the settings on the tree.
     """
     if revert not in (0, 1, None):
         raise BadRequest("Unexpected value for 'revert'")
-    
+
     session = current_app.db.session('relengapi')
     ch = session.query(model.DbStatusChange).get(id)
     if not ch:

--- a/relengapi/blueprints/treestatus/static/treestatus.js
+++ b/relengapi/blueprints/treestatus/static/treestatus.js
@@ -275,8 +275,8 @@ angular.module('treestatus').controller('TreeListController',
 
     $scope.revertChange = function(stack_id) {
         restapi({
-            url: '/treestatus/stack/' + stack_id,
-            method: 'REVERT',
+            url: '/treestatus/stack/' + stack_id + '?revert=1',
+            method: 'DELETE',
             while: 'reverting change',
         }).then(function (data, status, headers, config) {
             reloadTrees();

--- a/relengapi/blueprints/treestatus/test_treestatus.py
+++ b/relengapi/blueprints/treestatus/test_treestatus.py
@@ -503,7 +503,7 @@ def test_revert_stack_badarg(client):
     for arg in (2, -1, "january"):
         resp = client.open('/treestatus/stack/2?revert=%s' % arg,
                            method='DELETE')
-        eq_(resp.status_code, 503)
+        eq_(resp.status_code, 400)
 
 
 @test_context.specialize(db_setup=db_setup_stack, user=sheriff)

--- a/relengapi/blueprints/treestatus/test_treestatus.py
+++ b/relengapi/blueprints/treestatus/test_treestatus.py
@@ -500,7 +500,7 @@ def test_revert_stack_nosuch(client):
 @test_context.specialize(db_setup=db_setup_stack, user=sheriff)
 def test_revert_stack_badarg(client):
     """DELETEing /treestatus/stack/N with ?revert=<bad_argument> should fail"""
-    for arg in (2, -1, "january"):
+    for arg in (2, -1):
         resp = client.open('/treestatus/stack/2?revert=%s' % arg,
                            method='DELETE')
         eq_(resp.status_code, 400)

--- a/relengapi/blueprints/treestatus/test_treestatus.py
+++ b/relengapi/blueprints/treestatus/test_treestatus.py
@@ -450,9 +450,9 @@ def test_get_stack(client):
 
 @test_context.specialize(db_setup=db_setup_stack, user=sheriff)
 def test_revert_stack(app, client):
-    """REVERTing /treestatus/stack/N undoes the effects of that change and removes
-    it from the stack"""
-    resp = client.open('/treestatus/stack/2', method='REVERT')
+    """DELETEing /treestatus/stack/N with ?revert=1 undoes the effects of
+    that change and removes it from the stack"""
+    resp = client.open('/treestatus/stack/2?revert=1', method='DELETE')
     eq_(resp.status_code, 204)
 
     resp = client.get('/treestatus/trees')
@@ -484,16 +484,26 @@ def test_revert_stack(app, client):
 
 @test_context.specialize(db_setup=db_setup_stack, user=admin)
 def test_revert_stack_no_perms(app, client):
-    """REVERTing a stack without sheriff privs fails"""
-    resp = client.open('/treestatus/stack/2', method='REVERT')
+    """DELETEing a stack (using ?revert=1) without sheriff privs fails"""
+    resp = client.open('/treestatus/stack/2?revert=1', method='DELETE')
     eq_(resp.status_code, 403)
 
 
 @test_context.specialize(db_setup=db_setup_stack, user=sheriff)
 def test_revert_stack_nosuch(client):
-    """REVERTing /treestatus/stack/N where there's no such stack ID returns 404"""
-    resp = client.open('/treestatus/stack/99', method='REVERT')
+    """DELETEing /treestatus/stack/N with ?revert=1 where there's no such
+    stack ID returns 404"""
+    resp = client.open('/treestatus/stack/99?revert=1', method='DELETE')
     eq_(resp.status_code, 404)
+
+
+@test_context.specialize(db_setup=db_setup_stack, user=sheriff)
+def test_revert_stack_badarg(client):
+    """DELETEing /treestatus/stack/N with ?revert=<bad_argument> should fail"""
+    for arg in (2, -1, "january"):
+        resp = client.open('/treestatus/stack/2?revert=%s' % arg,
+                           method='DELETE')
+        eq_(resp.status_code, 503)
 
 
 @test_context.specialize(db_setup=db_setup_stack, user=sheriff)


### PR DESCRIPTION
For example, `REVERT` is not a standard verb.