### PR TITLE
Bug 1192021: log directly to mozdef, rather than via syslog

### DIFF
--- a/relengapi/blueprints/tokenauth/__init__.py
+++ b/relengapi/blueprints/tokenauth/__init__.py
@@ -281,7 +281,7 @@ def issue_token(body):
     # ensured `typ` is one of the recognized types.
     token = token_issuers[typ](body, requested_permissions)
     perms_str = ', '.join(str(p) for p in requested_permissions)
-    log = logger.bind(token_typ=token.typ, token_permissions=perms_str)
+    log = logger.bind(token_typ=token.typ, token_permissions=perms_str, mozdef=True)
     if token.id:
         log = log.bind(token_id=token.id)
     log.info("Issuing {} token to {} with permissions {}".format(
@@ -347,7 +347,7 @@ def revoke_token(token_id):
 
     perms_str = ', '.join(str(p) for p in token_data.permissions)
     log = logger.bind(token_typ=token_data.typ, token_permissions=perms_str,
-                      token_id=token_id)
+                      token_id=token_id, mozdef=True)
     log.info("Revoking {} token #{} with permissions {}".format(
         token_data.typ, token_data.id, perms_str))
 

--- a/relengapi/blueprints/tokenauth/usermonitor.py
+++ b/relengapi/blueprints/tokenauth/usermonitor.py
@@ -30,7 +30,7 @@ def monitor_users(job_status):
 
         perm_str = ', '.join(str(p) for p in token.permissions)
         log = logger.bind(token_typ=token.typ, token_id=token.id,
-                          token_user=token.user, token_permissions=perm_str)
+                          token_user=token.user, token_permissions=perm_str, mozdef=True)
         if disable and not token.disabled:
             logmsg = "Disabling {} token #{} for user {} with permissions {}".format(
                 token.typ, token.id, token.user, perm_str)

--- a/relengapi/blueprints/tooltool/__init__.py
+++ b/relengapi/blueprints/tooltool/__init__.py
@@ -150,7 +150,7 @@ def upload_batch(region=None, body=None):
     s3 = current_app.aws.connect_to('s3', region)
     for filename, info in body.files.iteritems():
         log = logger.bind(tooltool_sha512=info.digest, tooltool_operation='upload',
-                          tooltool_batch_id=batch.id)
+                          tooltool_batch_id=batch.id, mozdef=True)
         if info.algorithm != 'sha512':
             raise BadRequest("'sha512' is the only allowed digest algorithm")
         if not is_valid_sha512(info.digest):

--- a/relengapi/blueprints/tooltool/grooming.py
+++ b/relengapi/blueprints/tooltool/grooming.py
@@ -50,7 +50,7 @@ def replicate(job_status):
 
 
 def replicate_file(session, file, _test_shim=lambda: None):
-    log = logger.bind(tooltool_sha512=file.sha512)
+    log = logger.bind(tooltool_sha512=file.sha512, mozdef=True)
     config = current_app.config['TOOLTOOL_REGIONS']
     regions = set(config)
     file_regions = set([i.region for i in file.instances])
@@ -103,7 +103,7 @@ def check_file_pending_uploads(sha512):
 
 def verify_file_instance(sha512, size, key):
     """Verify that the given S3 Key matches the given size and digest."""
-    log = logger.bind(tooltool_sha512=sha512)
+    log = logger.bind(tooltool_sha512=sha512, mozdef=True)
     if key.size != size:
         log.warning("Uploaded file {} has unexpected size {}; expected "
                     "{}".format(sha512, key.size, size))
@@ -144,7 +144,7 @@ def check_pending_upload(session, pu, _test_shim=lambda: None):
     sha512 = pu.file.sha512
     size = pu.file.size
 
-    log = logger.bind(tooltool_sha512=sha512)
+    log = logger.bind(tooltool_sha512=sha512, mozdef=True)
 
     if time.now() < pu.expires:
         # URL is not expired yet

--- a/relengapi/tests/test_lib_logging.py
+++ b/relengapi/tests/test_lib_logging.py
@@ -2,8 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import json
 import logging
+import mock
+import mozdef_client
 import structlog
 
 from nose.tools import eq_
@@ -51,28 +52,26 @@ def test_setupConsoleLogging_loud(app):
 
 
 @with_setup(set_stdout_log, remove_stdout_log)
-@test_context.specialize(config={'JSON_STRUCTURED_LOGGING': True})
-def test_configure_logging(app):
-    hdlr = logging.handlers.BufferingHandler(100)
-    logging.getLogger(__name__).addHandler(hdlr)
-    try:
+@test_context.specialize(config={'MOZDEF_TARGET': 'https://localhost/mozdef'})
+def test_mozdef(app):
+    sent = []
+    orig_MozDefEvent = mozdef_client.MozDefEvent
+    with mock.patch('mozdef_client.MozDefEvent') as MozDefEvent:
+        def constructor(target):
+            msg = orig_MozDefEvent(target)
+            msg.send = lambda: sent.append(msg)
+            return msg
+        MozDefEvent.side_effect = constructor
+
         logger = structlog.get_logger(__name__)
-        logger.warn("test message")
+        logger.warn("unseen")
+        logger.warn("test message", mozdef=True)
 
-        # find that event in the handler..
-        for rec in hdlr.buffer:
-            try:
-                data = json.loads(rec.msg)
-            except Exception:
-                pass
-            if data["summary"] == "test message":
-                break
-        else:
-            assert 0, "login exception not logged"
+    # check that 'unseen' wasn't seen, since mozdef was not true
+    eq_([m.summary for m in sent], ["test message"])
 
-        # check a few other fields
-        eq_(data['source'], __name__)
-        eq_(data['severity'], 'WARNING')
-        eq_(data['tags'], ['relengapi'])
-    finally:
-        logging.getLogger(__name__).removeHandler(hdlr)
+    # check a few other fields in that one message logged
+    msg = sent[0]
+    eq_(msg.source, __name__)
+    eq_(msg._severity, orig_MozDefEvent.SEVERITY_WARNING)
+    eq_(msg.tags, ['relengapi'])

--- a/relengapi/tests/test_lib_logging.py
+++ b/relengapi/tests/test_lib_logging.py
@@ -66,12 +66,16 @@ def test_mozdef(app):
         logger = structlog.get_logger(__name__)
         logger.warn("unseen")
         logger.warn("test message", mozdef=True)
+        logger.warn("with attr", attr="foo", mozdef=True)
 
     # check that 'unseen' wasn't seen, since mozdef was not true
-    eq_([m.summary for m in sent], ["test message"])
+    eq_({m.summary for m in sent}, {"test message", "with attr"})
 
-    # check a few other fields in that one message logged
+    # check a few other fields in one of the messages
     msg = sent[0]
     eq_(msg.source, __name__)
     eq_(msg._severity, orig_MozDefEvent.SEVERITY_WARNING)
     eq_(msg.tags, ['relengapi'])
+
+    # and verify that the attribute showed up in details
+    assert any([m.details.get('attr') == 'foo' for m in sent])

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,8 @@ setup(
         # Temporary freeze until https://github.com/bhearsum/bzrest/pull/3 is fixed
         "bzrest==0.9",
         "structlog",
+        "mozdef_client",
+        "requests_futures",
     ],
     extras_require={
         'test': [
@@ -76,7 +78,7 @@ setup(
             '*/static/**.ttf',
             '*/static/**.woff',
         ],
-        'relengapi.alembic' : [
+        'relengapi.alembic': [
             '*.ini',
             '*.py',
             '*.mako',


### PR DESCRIPTION
This switches things around substantially: non-mozdef output is now
not JSON encoded, so it will be easier to read, and only messages tagged
with `mozdef=True` will be sent to mozdef.  This is currently limited to
tooltool and tokenauth.