### PR TITLE
Set LOGIN_DISABLED explicitly to False in the test context

### DIFF
--- a/relengapi/blueprints/slaveloan/__init__.py
+++ b/relengapi/blueprints/slaveloan/__init__.py
@@ -239,6 +239,7 @@ def get_machine_classes():
 
 
 @bp.route('/manual_actions')
+@flask_login.login_required
 @p.slaveloan.admin.require()
 @apimethod([rest.ManualAction], int, bool)
 def get_loan_actions(loan_id=None, all=False):

--- a/relengapi/blueprints/slaveloan/tests/test_slaveloan.py
+++ b/relengapi/blueprints/slaveloan/tests/test_slaveloan.py
@@ -13,9 +13,10 @@ def userperms(perms, email='me@example.com'):
     u._permissions = set(perms)
     return u
 
-test_context = TestContext()
+test_context = TestContext(disable_login_view=True)
 test_context_admin = TestContext(databases=['relengapi'],
-                                 user=userperms([p.slaveloan.admin]))
+                                 user=userperms([p.slaveloan.admin]),
+                                 disable_login_view=True)
 
 
 @test_context

--- a/relengapi/blueprints/slaveloan/tests/test_slaveloan.py
+++ b/relengapi/blueprints/slaveloan/tests/test_slaveloan.py
@@ -20,9 +20,9 @@ test_context_admin = TestContext(databases=['relengapi'],
 
 @test_context
 def test_ui_root(client):
-    "The root of the blueprint is accessible without login"
+    "The root of the blueprint is not accessible without login"
     rv = client.get('/slaveloan/')
-    eq_(rv.status_code, 200)
+    eq_(rv.status_code, 401)
 
 
 def test_ui_admin_required():
@@ -37,7 +37,7 @@ def test_ui_admin_required():
     def t(path, app, client):
         with app.test_request_context():
             resp = client.get(path)
-            eq_(resp.status_code, 403)
+            eq_(resp.status_code, 401)
 
     @test_context_admin
     def t2(path, app, client):

--- a/relengapi/docs/development/testing.rst
+++ b/relengapi/docs/development/testing.rst
@@ -46,7 +46,7 @@ Most tests take place in the context of an app, some databases, some data, and s
 
 To support, this, use the :py:class:`relengapi.lib.testing.context.TestContext` class.
 
-.. py:class:: TestContext(databases, app_setup, db_setup, db_teardown, reuse_app, config)
+.. py:class:: TestContext(databases, app_setup, db_setup, db_teardown, reuse_app, config, user, disable_login_view)
 
     :param databases: list by name of databases to set up
     :param app_setup: application setup function; see below
@@ -55,6 +55,7 @@ To support, this, use the :py:class:`relengapi.lib.testing.context.TestContext` 
     :param reuse_app: if true, only create a single Flask app and re-use it for all test cases
     :param config: application configuration
     :param user: a user object, substituted into ``current_user`` during each request
+    :param disable_login_view: a boolean, defaults to ``False``. Set to ``True`` to disable @login_required's redirect to the login page, and just test for a 401 response.
 
     A test context acts as a decorator to perform API-specific setup and tear-down for tests.
 

--- a/relengapi/lib/testing/context.py
+++ b/relengapi/lib/testing/context.py
@@ -47,6 +47,7 @@ class TestContext(object):
             return self._app
         config = self.options.get('config', {}).copy()
         config['TESTING'] = True
+        config['LOGIN_DISABLED'] = False  # Make @login_required enforced in tests.
         config['SECRET_KEY'] = 'test'
         config['SQLALCHEMY_DATABASE_URIS'] = uris = {}
         dbnames = self.options.get('databases', [])
@@ -68,6 +69,8 @@ class TestContext(object):
             @app.before_request
             def set_user():
                 auth.login_manager.reload_user(user)
+        # Don't issue a 302 redirection when login is needed.
+        auth.login_manager.login_view = None
 
         # set up the requested DBs
         for dbname in dbnames:

--- a/relengapi/lib/testing/context.py
+++ b/relengapi/lib/testing/context.py
@@ -25,6 +25,7 @@ class TestContext(object):
         'perms',  # TODO: doc
         'user',
         'accept',
+        'disable_login_view',
     ])
 
     def __init__(self, **options):
@@ -69,8 +70,6 @@ class TestContext(object):
             @app.before_request
             def set_user():
                 auth.login_manager.reload_user(user)
-        # Don't issue a 302 redirection when login is needed.
-        auth.login_manager.login_view = None
 
         # set up the requested DBs
         for dbname in dbnames:
@@ -123,8 +122,13 @@ class TestContext(object):
 
         if 'db_setup' in self.options:
             self.options['db_setup'](app)
+        old_login_view = auth.login_manager.login_view
+        if self.options.get('disable_login_view', False):
+            # Don't issue a 302 redirection when login is needed.
+            auth.login_manager.login_view = None
         try:
             wrapped(*given_args, **kwargs)
         finally:
+            auth.login_manager.login_view = old_login_view
             if 'db_teardown' in self.options:
                 self.options['db_teardown'](app)

--- a/relengapi/tests/test_lib_permissions.py
+++ b/relengapi/tests/test_lib_permissions.py
@@ -119,12 +119,12 @@ def test_require_can(app):
             @permissions.require(perms.test.writer, perms.test.deleter)
             def bad_func_browser_anon():
                 return "ok"
-            assert_raises(werkzeug.exceptions.Unauthorized, bad_func_browser_anon)
+            eq_(bad_func_browser_anon().status_code, 302)
 
             @perms.test.deleter.require()
             def bad_meth_browser_anon():
                 return "ok"
-            assert_raises(werkzeug.exceptions.Unauthorized, bad_meth_browser_anon)
+            eq_(bad_meth_browser_anon().status_code, 302)
 
         # empty are invalid
         assert_raises(AssertionError, permissions.require)

--- a/relengapi/tests/test_lib_permissions.py
+++ b/relengapi/tests/test_lib_permissions.py
@@ -119,12 +119,12 @@ def test_require_can(app):
             @permissions.require(perms.test.writer, perms.test.deleter)
             def bad_func_browser_anon():
                 return "ok"
-            eq_(bad_func_browser_anon().status_code, 302)
+            assert_raises(werkzeug.exceptions.Unauthorized, bad_func_browser_anon)
 
             @perms.test.deleter.require()
             def bad_meth_browser_anon():
                 return "ok"
-            eq_(bad_meth_browser_anon().status_code, 302)
+            assert_raises(werkzeug.exceptions.Unauthorized, bad_meth_browser_anon)
 
         # empty are invalid
         assert_raises(AssertionError, permissions.require)


### PR DESCRIPTION
This is to solve https://github.com/maxcountryman/flask-login/commit/2fc6a7e06b560233eadb44f8eba74e2a1bce88be on our local end, and to make sure that tests which care to verify that login is required will be able to pass accurately.