### PR TITLE
Bugfix - AutoType should allow newlines for type comments

### DIFF
--- a/relengapi/lib/apidoc.py
+++ b/relengapi/lib/apidoc.py
@@ -267,7 +267,11 @@ class AutoTypeDirective(Directive):
         # extract the attribute documentation.
         analyzer = ModuleAnalyzer.for_module(ty.__module__)
         module_attrs = analyzer.find_attr_docs()  # (scope is broken!)
-        return {k[1]: v[0] for k, v in module_attrs.iteritems()}
+        # Make sure we can split lines for type docs on long lines
+        attrs_docs = {}
+        for k, v in module_attrs.iteritems():
+            attrs_docs[k[1]] = "\n".join(v).strip()
+        return attrs_docs
 
     def run(self):
         src = '<autotype>'


### PR DESCRIPTION
I noticed that docs were getting truncated, e.g.

https://api.pub.build.mozilla.org/docs/usage/tokenauth/#types
> **typ** (*Enum(prm, tmp, usr)*) -- token type (short string). This defaults to `prm` for backward

This patch makes that:
> **typ** (*Enum(prm, tmp, usr)*) -- token type (short string). This defaults to `prm` for backward compatibility, but should always be specified.

There are many other places in the code this is an issue