### PR TITLE
mock-1.3.0 install is buggy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     extras_require={
         'test': [
             'nose',
-            'mock',
+            'funcsigs',  # https://github.com/mozilla/build-relengapi/issues/345
             'coverage',
             'pep8',
             'mockldap',


### PR DESCRIPTION
If you run against the lastest mock, it fails because funcsigs isn't installed - see https://github.com/testing-cabal/mock/issues/316.

Easiest fix is to temporarily require funcsigs ourselves.