### PR TITLE
Production code shouldn't require nose

### DIFF
--- a/relengapi/blueprints/base/__init__.py
+++ b/relengapi/blueprints/base/__init__.py
@@ -13,12 +13,18 @@ from alembic.config import Config
 from flask import Blueprint
 from flask import Flask
 from flask import current_app
-from nose.plugins.base import Plugin
 
 import relengapi
 from relengapi.blueprints.base.alembic_wrapper import AlembicSubcommand
 from relengapi.lib import logging as relengapi_logging
 from relengapi.lib import subcommands
+
+try:
+    from nose.plugins.base import Plugin
+    assert Plugin
+except ImportError:  # pragma: no cover
+    Plugin = None
+
 
 bp = Blueprint('base', __name__)
 logger = logging.getLogger(__name__)
@@ -71,17 +77,18 @@ class CreateDBSubcommand(subcommands.Subcommand):
                 command.stamp(alembic_cfg, "head")
 
 
-class ResetLogging(Plugin):
+if Plugin:
+    class ResetLogging(Plugin):
 
-    """Reset the logging context after each test."""
+        """Reset the logging context after each test."""
 
-    def configure(self, options, conf):
-        super(ResetLogging, self).configure(options, conf)
-        # enable automatically
-        self.enabled = True
+        def configure(self, options, conf):
+            super(ResetLogging, self).configure(options, conf)
+            # enable automatically
+            self.enabled = True
 
-    def afterTest(self, test):
-        relengapi_logging.reset_context()
+        def afterTest(self, test):
+            relengapi_logging.reset_context()
 
 
 class RunTestsSubcommand(subcommands.Subcommand):


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/data/releng-stage/src/relengapi/virtualenv/bin/relengapi", line 9, in <module>
    load_entry_point('relengapi==3.3.0', 'console_scripts', 'relengapi')()
  File "/data/releng-stage/src/relengapi/virtualenv/lib/python2.7/site-packages/pkg_resources.py", line 356, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/data/releng-stage/src/relengapi/virtualenv/lib/python2.7/site-packages/pkg_resources.py", line 2439, in load_entry_point
    return ep.load()
  File "/data/releng-stage/src/relengapi/virtualenv/lib/python2.7/site-packages/pkg_resources.py", line 2155, in load
    ['__name__'])
  File "/data/releng-stage/src/relengapi/virtualenv/lib/python2.7/site-packages/relengapi/cmd.py", line 11, in <module>
    import relengapi.app
  File "/data/releng-stage/src/relengapi/virtualenv/lib/python2.7/site-packages/relengapi/app.py", line 85, in <module>
    'treestatus',
  File "/data/releng-stage/src/relengapi/virtualenv/lib/python2.7/site-packages/relengapi/app.py", line 71, in _load_bp
    relengapi_mod = __import__('relengapi.blueprints.' + n)
  File "/data/releng-stage/src/relengapi/virtualenv/lib/python2.7/site-packages/relengapi/blueprints/base/__init__.py", line 16, in <module>
    from nose.plugins.base import Plugin
ImportError: No module named nose.plugins.base
```

This should be solveable with a try/except block, in the meantime since nose doesn't break prod I'm installing it for our staging system.