### PR TITLE
restapi Angular service should set Content-Type on requests

### DIFF
--- a/relengapi/blueprints/tokenauth/static/tokens.js
+++ b/relengapi/blueprints/tokenauth/static/tokens.js
@@ -111,17 +111,12 @@ angular.module('tokens').controller('NewTokenController', function($scope, resta
         var permissions = $scope.newtoken.permissions;
         var description = $scope.newtoken.description;
 
-        restapi({
-            url: '/tokenauth/tokens',
-            method: 'POST',
-            headers: {'Content-Type': 'application/json; charset=utf-8'},
-            data: JSON.stringify({
+        restapi.post('/tokenauth/tokens', {
                 typ: typ,
                 permissions: permissions,
                 description: description,
-            }),
-            while: 'issuing token',
-        }).then(function(response) {
+            }, {while: 'issuing token'}
+        ).then(function(response) {
             if (response.data.result.token) {
                 $scope.token = response.data.result.token;
                 $scope.tokens.push(response.data.result);


### PR DESCRIPTION
I just had to add `headers: {'Content-Type': 'application/json'}` to a restapi request; restapi should do this for me when there is data present.