### PR TITLE
Replace use of flags in string.replace with a RegExp

### DIFF
--- a/relengapi/blueprints/treestatus/static/treestatus.js
+++ b/relengapi/blueprints/treestatus/static/treestatus.js
@@ -31,7 +31,7 @@ angular.module('treestatus').filter('urlencode', function() {
 // convert a tree status to a CSS class name
 angular.module('treestatus').filter('status2class', function() {
     return function(input) {
-        return input.toLowerCase().replace(" ", "_", "g");
+        return input.toLowerCase().replace(/ /g, "_");
     };
 });
 


### PR DESCRIPTION
Per https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/replace
flags is deprecated and not supported in V8.