### PR TITLE
Bug 1215215 - Add link to main treestatus page to tree page headers

### DIFF
--- a/relengapi/blueprints/treestatus/static/index.html
+++ b/relengapi/blueprints/treestatus/static/index.html
@@ -8,7 +8,7 @@
                 <button class="btn btn-default"
                     ng-click="refresh()"><span class="glyphicon glyphicon-refresh">
             </div>
-            <h1 class="treestatus">TreeStatus</h1>
+            <h1 class="treestatus"><a href="/treestatus">TreeStatus</a></h1>
         </div>
     </div>
     <div class="row">

--- a/relengapi/blueprints/treestatus/static/tree.html
+++ b/relengapi/blueprints/treestatus/static/tree.html
@@ -8,7 +8,7 @@
                 <button class="btn btn-default"
                     ng-click="refresh()"><span class="glyphicon glyphicon-refresh">
             </div>
-            <h2 class="treestatus">{{tree.tree}} status is
+            <h2 class="treestatus"><a href="/treestatus">{{tree.tree}}</a> status is
                 <span class="{{tree.status|status2class}}">{{tree.status|uppercase}}</span>
             </h2><br/>
             <h2 class="treestatus" ng-if="tree.reason">Reason:


### PR DESCRIPTION
This adds an easier-to-click target for getting back to the main treeherder page.