### PR TITLE
Bug 1245170: Allow tooltool uploads with non-user-associated tokens

### DIFF
--- a/relengapi/blueprints/tooltool/__init__.py
+++ b/relengapi/blueprints/tooltool/__init__.py
@@ -135,7 +135,9 @@ def upload_batch(region=None, body=None):
     try:
         body.author = current_user.authenticated_email
     except AttributeError:
-        raise BadRequest("Could not determine authenticated username")
+        # no authenticated_email -> use the stringified user (probably a token
+        # ID)
+        body.author = str(current_user)
 
     # verify permissions based on visibilities
     visibilities = set(f.visibility for f in body.files.itervalues())


### PR DESCRIPTION
Still needs tests; see https://bugzilla.mozilla.org/show_bug.cgi?id=1245170 for the motivation.