### PR TITLE
Bug 1248205 - Don't allow changing the motd for more than one tree at a time

### DIFF
--- a/relengapi/blueprints/treestatus/static/treeStatusControl.html
+++ b/relengapi/blueprints/treestatus/static/treeStatusControl.html
@@ -47,7 +47,7 @@
                 </div>
             </div>
             <hr />
-            <div class="form-group">
+            <div class="form-group" ng-hide="plural">
                 <label for="reason">Message of the Day</label>
                 <input type="text" name="reason" class="form-control"
                     placeholder="(no change)" ng-model="message_of_the_day">

--- a/relengapi/blueprints/treestatus/static/treestatus.js
+++ b/relengapi/blueprints/treestatus/static/treestatus.js
@@ -147,8 +147,8 @@ function(allowed_statuses, allowed_tags, restapi) {
                 var update = {trees: scope.trees};
 
                 // only update the MOTD if it's nonempty (which precludes empty
-                // MOTD's, but that's OK)
-                if (scope.message_of_the_day) {
+                // MOTD's, but that's OK) and only if a single tree is selected
+                if (scope.message_of_the_day && scope.plural == false) {
                     update['message_of_the_day'] = scope.message_of_the_day;
                 };
 


### PR DESCRIPTION
Not really tested much, but I think this should work. 

The change to treeStatusControl.html should hide the MotD elements on the main treestatus page unless only a single tree is selected selected (it won't show without first selecting a single tree), while still leaving it visible on the individual tree pages.

The change to treestatus.js should prevent mass clobbering if you select a single tree on the main page, type a MotD into the form, then continue to select additional trees before clicking "Update".

I was going to use an ng-if instead of ng-hide, but that seemed to break updating MotDs entirely.