### PR TITLE
Correct Authorization: example HTTP syntax - fixes #377

### DIFF
--- a/relengapi/docs/usage/requests-responses.rst
+++ b/relengapi/docs/usage/requests-responses.rst
@@ -15,8 +15,8 @@ For example:
 .. code-block:: none
 
     $ curl --data-ascii '{"description": "new token", "permissions": ["base.tokens.issue"]}' \
-        -H 'Content-Type: application/json'
-        -H 'Authorization Bearer your.token.here'
+        -H 'Content-Type: application/json' \
+        -H 'Authorization: Bearer your.token.here' \
         http://api.pub.build.mozilla.org/tokenauth/tokens
 
 API Responses

--- a/relengapi/docs/usage/tokenauth.rst
+++ b/relengapi/docs/usage/tokenauth.rst
@@ -12,7 +12,7 @@ Tokens are opaque strings (actually JSON Web Tokens) which are provided in the A
 .. code-block:: none
 
     GET /some/resource HTTP/1.1
-    Authorization Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6OSwidiI6MX0.pVmY1aTyASlf24h4acVOiqNgt85mfViXDTvxLsY_qdY
+    Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6OSwidiI6MX0.pVmY1aTyASlf24h4acVOiqNgt85mfViXDTvxLsY_qdY
 
 Each token permits a limited set of permissions, specified when the token is issued.
 


### PR DESCRIPTION
Several places were missing the required ':' for a valid HTTP header.
